### PR TITLE
Build `readable_secs` on `Dates.canonicalize`

### DIFF
--- a/src/feedback.jl
+++ b/src/feedback.jl
@@ -33,7 +33,7 @@ function duration_estimate(feedback::Feedback)
     time_total = round(Int,time_per_step*n_timesteps)
     time_to_go = round(Int,time_per_step*(n_timesteps-i))
 
-    s1 = "Model integration will take approximately "*readable_secs(time_total)*","
+    s1 = "Model integration will take approximately $(readable_secs(time_total)),"
     s2 = "and is hopefully done on "*
             Dates.format(Dates.now() + Dates.Second(time_to_go),Dates.RFC1123Format)
 
@@ -113,7 +113,7 @@ function feedback_end!(feedback::Feedback)
     t_end = time()          # time when the simulation ends
     feedback.t_end = t_end  # store in struct
 
-    s = " Integration done in "*readable_secs(t_end-t_start)*"."
+    s = " Integration done in $(readable_secs(t_end-t_start))."
     verbose && println(s)
     if output
         write(progress_txt,"\n"*s[2:end]*"\n")  # close txt file with last output

--- a/src/utility_functions.jl
+++ b/src/utility_functions.jl
@@ -15,28 +15,26 @@ function clip_negatives!(A::AbstractArray{T}) where T
 end
 
 """
-    time_string = readable_secs(secs::Real)
+    readable_secs(secs::Real) -> Dates.CompoundPeriod
 
-Returns a human readable string representing seconds in terms of days, hours, minutes or seconds,
-rounding to either (days, hours), (hours, minutes), (minutes, seconds), or seconds with 1 decimal
-place accuracy for >10s and two for less.
-E.g. 
+Returns `Dates.CompoundPeriod` rounding to either (days, hours), (hours, minutes), (minutes,
+seconds), or seconds with 1 decimal place accuracy for >10s and two for less.
+E.g.
 ```julia
 julia> readable_secs(12345)
-"3h, 25min"
+3 hours, 26 minutes
 ```
 """
 function readable_secs(secs::Real)
-    days = floor(Int,secs/3600/24)
-    hours = floor(Int,(secs/3600) % 24)
-    minutes = floor(Int,(secs/60) % 60)
-    seconds = floor(Int,secs%3600%60)
-    secs1f = @sprintf "%.1fs" secs%3600%60
-    secs2f = @sprintf "%.2fs" secs%3600%60
-
-    days > 0 && return "$(days)d, $(hours)h"
-    hours > 0 && return "$(hours)h, $(minutes)min"
-    minutes > 0 && return "$(minutes)min, $(seconds)s"
-    seconds > 10 && return secs1f
-    return secs2f
+    millisecs = Dates.Millisecond(round(secs * 10 ^ 3))
+    if millisecs >= Dates.Day(1)
+        return Dates.canonicalize(round(millisecs, Dates.Hour))
+    elseif millisecs >= Dates.Hour(1)
+        return Dates.canonicalize(round(millisecs, Dates.Minute))
+    elseif millisecs >= Dates.Minute(1)
+        return Dates.canonicalize(round(millisecs, Dates.Second))
+    elseif millisecs >= Dates.Second(10)
+        return Dates.canonicalize(round(millisecs, Dates.Millisecond(100)))
+    end
+    return Dates.canonicalize(round(millisecs, Dates.Millisecond(10)))
 end

--- a/test/utility_functions.jl
+++ b/test/utility_functions.jl
@@ -1,3 +1,5 @@
+using Dates: CompoundPeriod, Day, Hour, Minute, Second, Millisecond
+
 @testset "Increasing/decresing vectors" begin
     @test SpeedyWeather.isincreasing(collect(1:10))
     @test SpeedyWeather.isincreasing(sort(rand(10)))
@@ -25,11 +27,11 @@ end
 end
 
 @testset "readable secs feedback" begin
-    @test SpeedyWeather.readable_secs(123456) == "1d, 10h"
-    @test SpeedyWeather.readable_secs(12345) == "3h, 25min"
-    @test SpeedyWeather.readable_secs(1234) == "20min, 34s"
-    @test SpeedyWeather.readable_secs(123) == "2min, 3s"
-    @test SpeedyWeather.readable_secs(12.3) == "12.3s"
-    @test SpeedyWeather.readable_secs(1.23) == "1.23s"
-    @test SpeedyWeather.readable_secs(0.123) == "0.12s"
+    @test SpeedyWeather.readable_secs(123456) == CompoundPeriod(Day(1), Hour(10))
+    @test SpeedyWeather.readable_secs(12345) == CompoundPeriod(Hour(3), Minute(26))
+    @test SpeedyWeather.readable_secs(1234) == CompoundPeriod(Minute(20), Second(34))
+    @test SpeedyWeather.readable_secs(123) == CompoundPeriod(Minute(2), Second(3))
+    @test SpeedyWeather.readable_secs(12.3) == CompoundPeriod(Second(12), Millisecond(300))
+    @test SpeedyWeather.readable_secs(1.23) == CompoundPeriod(Second(1), Millisecond(230))
+    @test SpeedyWeather.readable_secs(0.123) == CompoundPeriod(Second(0), Millisecond(120))
 end


### PR DESCRIPTION
I don't know if you'll like it as this is a bit more verbose than the current `readable_secs`, but `Dates.canonicalize` allows you to automatically get the readable strings and (_totally biased opinion coming_) I personally find the proposed implementation easier to read.  Let me know what you think and feel free to reject it :slightly_smiling_face:

Side note, I have a collaborator calling from Julia the Speedy model written in Fortran, maybe we should talk at some point :wink: 