### PR TITLE
Take exponential of pres_grid for parametrizations

### DIFF
--- a/src/humidity.jl
+++ b/src/humidity.jl
@@ -40,7 +40,7 @@ function get_saturation_specific_humidity!(
     sat_spec_humidity ::Array{NF,3},
     sat_vap_pressure  ::Array{NF,3},
     temp_grid         ::Array{NF,3},
-    pres              ::Array{NF,2},
+    pres_grid         ::Array{NF,2},
     model             ::ModelSetup,
 ) where {NF<:AbstractFloat}
     @unpack nlon, nlat, nlev, σ_levels_full = model.geospectral.geometry
@@ -52,7 +52,7 @@ function get_saturation_specific_humidity!(
 
     for k = 1:nlev, j = 1:nlat, i = 1:nlon
         sat_spec_humidity[i, j, k] = mol_ratio * sat_vap_pressure[i, j, k] /
-            (pres[i, j] * σ_levels_full[k] - one_minus_mol_ratio * sat_vap_pressure[i, j, k])
+            (pres_grid[i, j] * σ_levels_full[k] - one_minus_mol_ratio * sat_vap_pressure[i, j, k])
     end
 
     return nothing

--- a/src/tendencies_parametrizations.jl
+++ b/src/tendencies_parametrizations.jl
@@ -6,6 +6,13 @@ function parametrization_tendencies!(
     Diag::DiagnosticVariables{NF},
     M,
 ) where {NF<:AbstractFloat}
+    @unpack pres_grid = Diag.grid_variables
+
+    # The prognostic variable pres has units of log(hPa), whereas the grid-point pressure
+    # field which we require for the parametrizations has units of hPa, so we take the
+    # exponential here.
+    @. pres_grid = exp(pres_grid)
+
     get_large_scale_condensation_tendencies!(Diag, M)
 
     #Calculate


### PR DESCRIPTION
#91 

@milankl let me know if this is consistent with what you had in mind.

I see that `pres_grid` is also used [here](https://github.com/milankl/SpeedyWeather.jl/blob/a1ec01d3fe909e00eaaae43cb78c3cca28d837cb/src/tendencies_dynamics.jl#L340) as well as for the Bernoulli potential, both of which are, I think. only relevant for the shallow water equations.

I'm lacking the big picture slightly, but do you think it's both safe and not too confusing to do the conversion in this way?