### PR TITLE
Grid indexing

### DIFF
--- a/src/grids.jl
+++ b/src/grids.jl
@@ -1,4 +1,3 @@
-# Make AbstractGrid subtype of AbstractVector as the data within is unravelled into a vec
 """
     abstract type AbstractGrid{T} <: AbstractVector{T} end
 
@@ -195,7 +194,8 @@ get_nresolution(G::AbstractHEALPixGrid) = G.nside
 
 # define nlat_half for all grids (HEALPixGrid is different as it doesn't use nlat_half as resolution parameter)
 get_nlat_half(::Type{<:AbstractGrid},nlat_half::Integer) = nlat_half
-get_nlat_half(::Type{<:AbstractHEALPixGrid},nside::Integer) = (nlat_healpix(nside)+1)÷2
+get_nlat_half(::Type{<:AbstractHEALPixGrid},nside::Integer) = 2nside
+get_nlat_half(::G,n::Integer) where {G<:AbstractGrid} = get_nlat_half(G,n) 
 
 # define whether there's an odd number of latitude rings for a grid
 nlat_odd(::Type{<:FullGaussianGrid}) = false
@@ -203,6 +203,9 @@ nlat_odd(::Type{<:FullClenshawGrid}) = true
 nlat_odd(::Type{<:AbstractOctahedralGrid}) = false
 nlat_odd(::Type{<:AbstractHEALPixGrid}) = true
 nlat_odd(grid::AbstractGrid) = nlat_odd(typeof(grid))
+
+get_nlat(Grid::Type{<:AbstractGrid},n::Integer) = 2get_nlat_half(Grid,n) - nlat_odd(Grid)
+get_nlat(grid::Grid) where {Grid<:AbstractGrid} = get_nlat(Grid,get_nresolution(grid))
 
 # return the maxmimum number of longitude points for a grid and its resolution parameter nlat_half/nside
 get_nlon(::Type{<:AbstractFullGrid},nlat_half::Integer) = 4nlat_half
@@ -295,29 +298,9 @@ function get_colatlons(G::Type{<:AbstractHEALPixGrid},nside::Integer)
     return colats, lons
 end
 
-# INDEXING HELPERS
-# function get_last_index_per_ring(G::Type{<:AbstractGrid},nresolution::Integer)
-#     nlat_half = get_nlat_half(G,nresolution)    # contains equator for HEALPix
-#     nlat = 2nlat_half - nlat_odd(G)             # one less if grids have odd # of latitude rings
-#     nlons = [get_nlon_per_ring(G,nresolution,i) for i in 1:nlat]
-#     last_indices = cumsum(nlons)                # last index is always sum of all previous points
-#     return last_indices
-# end
-
-# function get_first_index_per_ring(G::Type{<:AbstractGrid},nresolution::Integer)
-#     last_indices = get_last_index_per_ring(G,nresolution)
-#     first_indices = zero(last_indices)
-#     first_indices[1] = 1
-#     for i in 1:length(first_indices)-1
-#         first_indices[i+1] = last_indices[i]+1
-#     end
-#     return first_indices
-# end
-
 function eachring(grid::G) where {G<:AbstractGrid}
-    nlat_half = get_nlat_half(G,get_nresolution(grid))  # contains equator for HEALPix
-    nlat = 2nlat_half - nlat_odd(G)                     # -1 for odd # of latitude rings
-    return Base.OneTo(nlat)                             # return iterable range
+    rings = [each_index_in_ring(grid,j) for j in 1:get_nlat(grid)]
+    return rings                                            # return Vector{UnitRange}
 end
 
 function eachring(grids::Grid...) where {Grid<:AbstractGrid}
@@ -378,7 +361,7 @@ function each_index_in_ring(::Type{<:AbstractHEALPixGrid},  # function for HEALP
     return index_1st:index_end                              # range of i's in ring
 end
 
-@inline function each_index_in_ring(grid::G,j::Integer) where {G<:AbstractGrid}
+function each_index_in_ring(grid::G,j::Integer) where {G<:AbstractGrid}
     return each_index_in_ring(G,j,get_nresolution(grid))
 end
 

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -15,7 +15,7 @@ scale_coslat⁻²!(A::AbstractMatrix,G::Geometry) = A.*G.coslat⁻²'
 
 Generic latitude scaling applied to `A` in-place with latitude-like vector `v`."""
 function _scale_lat!(A::AbstractGrid{NF},v::AbstractVector) where {NF<:AbstractFloat}
-    @boundscheck length(get_nlat(A)) == length(v) || throw(BoundsError)
+    @boundscheck get_nlat(A) == length(v) || throw(BoundsError)
     
     rings = eachring(A)
     

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -15,10 +15,13 @@ scale_coslat⁻²!(A::AbstractMatrix,G::Geometry) = A.*G.coslat⁻²'
 
 Generic latitude scaling applied to `A` in-place with latitude-like vector `v`."""
 function _scale_lat!(A::AbstractGrid{NF},v::AbstractVector) where {NF<:AbstractFloat}
-    @boundscheck length(eachring(A)) == length(v) || throw(BoundsError)
-    @inbounds for j in eachring(A)
+    @boundscheck length(get_nlat(A)) == length(v) || throw(BoundsError)
+    
+    rings = eachring(A)
+    
+    @inbounds for (j,ring) in enumerate(rings)
         vj = convert(NF,v[j])
-        for ij in each_index_in_ring(A,j)
+        for ij in ring
             A[ij] *= vj
         end
     end

--- a/src/tendencies_dynamics.jl
+++ b/src/tendencies_dynamics.jl
@@ -354,7 +354,7 @@ function bernoulli_potential!(  B::AbstractGrid{NF},    # Output: Bernoulli pote
                                 ) where {NF<:AbstractFloat}
     
     @unpack coslat⁻² = G
-    @boundscheck length(coslat⁻²) == length(get_nlat(U)) || throw(BoundsError)
+    @boundscheck length(coslat⁻²) == get_nlat(U) || throw(BoundsError)
 
     one_half = convert(NF,0.5)                      # convert to number format NF
     gravity = convert(NF,g)
@@ -380,7 +380,7 @@ function volume_fluxes!(    uh_coslat⁻¹::AbstractGrid{NF},  # Output: zonal v
                             ) where {NF<:AbstractFloat}                                   
 
     @unpack coslat⁻² = G
-    @boundscheck length(coslat⁻²) == length(get_nlat(η)) || throw(BoundsError) 
+    @boundscheck length(coslat⁻²) == get_nlat(η) || throw(BoundsError) 
 
     H₀ = convert(NF,H₀)
 

--- a/test/grids.jl
+++ b/test/grids.jl
@@ -73,8 +73,11 @@ end
         n = 32      # resolution parameter nlat_half/nside
         grid = zeros(G,n)
 
-        for i in SpeedyWeather.eachring(grid)
-            for ij in SpeedyWeather.each_index_in_ring(grid,i)
+        # precompute indices and boundscheck
+        rings = SpeedyWeather.eachring(grid,grid)   
+
+        for (j,ring) in enumerate(rings)
+            for ij in ring
                 grid[ij] += 1
             end
         end


### PR DESCRIPTION
@maximilian-gelbrecht as discussed this PR implements a new indexing syntax for grids.

This is now `rings::Vector{UnitRange}`, e.g.
```julia
julia> grid = zeros(OctahedralGaussianGrid,8);
julia> rings = eachring(grid)
16-element Vector{UnitRange{Int64}}:
 1:20
 21:44
 45:72
 73:104
 105:140
 141:180
 181:224
 225:272
 273:320
 321:364
 365:404
 405:440
 441:472
 473:500
 501:524
 525:544
```
but could also be easily changed to `NTuple{nlat,UnitRange{UInt64}}` or a generator of tuples. For some reason creating a vector is faster than an NTuple and allocates less memory, not sure why, but I believe a generator would just move the actual calculation of the ring indices into the loop, which is probably something we want to avoid on the GPU? At T31 `rings` is about 1KB large, whereas 2 gridded fields are more like 80KB so any overhead because of communication should be negligible I hope. For higher resolution that's even better because rings scales with O(nlat) but the grids with O(nlat^2). This PR also rewrites the ring-based loops as
```julia
rings = eachring(u_grid,v_grid)       # precompute ring indices, boundscheck

@inbounds for (j,ring) in enumerate(rings)
    for ij in ring
        u_grid[ij]
        v_grid[ij]
    end
end
```

and
```julia
@inbounds for ij in eachgridpoint(u_grid,v_grid)
    u_grid[ij]
    v_grid[ij]
end
```
works as before.