### PR TITLE
Add kernelabstractions_adtests CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+      - kernelabstractions_adtests
   push:
     branches:
       - main

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,10 +3,11 @@ on:
   pull_request:
     branches:
       - main
-      - kernelabstractions_adtests
+      - gpu
   push:
     branches:
       - main
+      - gpu
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We should have CI for the GPU/AD development branch on pull requests. I think this was also why the error wasn't caught. Only the doc was built, but the tests were not run 