### PR TITLE
Vorticity initial conditions

### DIFF
--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -109,7 +109,8 @@ The default values of the keywords define the default model setup.
 
     # INITIAL CONDITIONS
     seed::Int = abs(rand(Int))          # a random seed that's used in initialize_speedy for the global RNG
-    initial_conditions::Symbol=:barotropic_vorticity    # :rest, :barotropic_vorticity or :restart
+    initial_conditions::Union{Symbol, Vector}=:barotropic_vorticity    # :rest, :barotropic_vorticity, :restart
+                                                                       # or Vector of LowerTriangularMatrix of Vorticity 
 
     # OUTPUT
     verbose::Bool = true            # print dialog for feedback

--- a/test/initialize.jl
+++ b/test/initialize.jl
@@ -59,6 +59,36 @@ end
     """
 end
 
+
+@testset "Initialize from Vorticity IC" begin
+
+    # BAROTROPIC MODEL
+    progn, diagn, model = initialize_speedy(initial_conditions=:rest,model=:barotropic)
+
+    ic = [layer.leapfrog[1].vor for layer in progn.layers]
+    progn, diagn, model = initialize_speedy(initial_conditions=ic,model=:barotropic)
+    for layers in progn.layers
+        for leapfrog in layers.leapfrog
+            @test all(leapfrog.vor .== 0)
+        end
+    end
+
+    # SHALLOW WATER MODE
+    progn, diagn, model = initialize_speedy(initial_conditions=:rest,model=:shallowwater)
+
+    ic = [layer.leapfrog[1].vor for layer in progn.layers]
+    progn, diagn, model = initialize_speedy(initial_conditions=ic,model=shallowwater)
+    for layers in progn.layers
+        for leapfrog in layers.leapfrog
+            @test all(leapfrog.vor .== 0)
+            @test all(leapfrog.div .== 0)
+        end
+    end
+    @test all(progn.pres.leapfrog[1] .== 0)
+    @test all(progn.pres.leapfrog[2] .== 0)
+end
+
+
 @testset "Initialize speedy with different models" begin
     _,_,m_barotrop = initialize_speedy(model=:barotropic)
     _,_,m_shalloww = initialize_speedy(model=:shallowwater)


### PR DESCRIPTION
I first wanted to do it by requiring to hand over an instance of `PrognosticVariables`, but for that you have the problem again that  `PrognosticVariables` are defined at the time the inputs are handles. Changing that would need larger changes, so I am thinking handing over initial conditions as `Vector{LowerTriangluarMatrix}` is fine 