### PR TITLE
HEALPix4Grid and FullHEALPix4Grid implementation

### DIFF
--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -43,7 +43,9 @@ module SpeedyWeather
             FullGaussianGrid,
             OctahedralGaussianGrid,
             OctahedralClenshawGrid,
-            HEALPixGrid
+            HEALPixGrid,
+            HEALPix4Grid,
+            FullHEALPix4Grid
 
     # EXPORT STRUCTS
     export  Parameters,

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -8,7 +8,7 @@ struct Geometry{NF<:AbstractFloat}      # NF: Number format
 
     # GRID TYPE AND RESOLUTION
     Grid::Type{<:AbstractGrid}
-    nresolution::Int    # resolution parameter nlat_half or nside for HEALPix
+    nresolution::Int    # resolution parameter nlat_half or nside for HEALPix/HEALPix4
 
     # GRID-POINT SPACE
     nlon_max::Int       # Maximum number of longitudes (at/around Equator)
@@ -16,11 +16,11 @@ struct Geometry{NF<:AbstractFloat}      # NF: Number format
     nlat::Int           # Number of latitudes
     nlev::Int           # Number of vertical levels
     nlat_half::Int      # Number of latitudes in one hemisphere (incl Equator)
-    nside::Int          # HEALPix only, nside^2 are the # of grid points in each of the 12 base pixels
+    nside::Int          # HEALPix and HEALPix4 only, nside^2 are the # of grid points in each of the 12 (or 4) base pixels
     npoints::Int        # total number of grid points
     radius_earth::Real  # Earth's radius [m]
 
-    # LATITUDES (either Gaussian, equi-angle or HEALPix lats, depending on grid)
+    # LATITUDES (either Gaussian, equi-angle, HEALPix or HEALPix4 lats, depending on grid)
     lat::Vector{NF}         # array of latitudes (π/2...-π/2)
     latd::Vector{Float64}   # array of latitudes in degrees (90˚...-90˚)
     colat::Vector{NF}       # array of colatitudes (0...π)
@@ -79,15 +79,15 @@ function Geometry(P::Parameters,Grid::Type{<:AbstractGrid})
     @unpack n_stratosphere_levels = P               # number of vertical levels used for stratosphere
 
     # RESOLUTION PARAMETERS
-    nresolution = get_resolution(Grid,trunc)        # resolution parameter, nlat_half or nside for HEALPixGrid
-    nlat_half = get_nlat_half(Grid,nresolution)     # contains equator for HEALPix
+    nresolution = get_resolution(Grid,trunc)        # resolution parameter, nlat_half or nside for HEALPixGrid/HEALPix4Grid
+    nlat_half = get_nlat_half(Grid,nresolution)     # contains equator for HEALPix,HEALPix4 and Clenshaw
     nlat = 2nlat_half - nlat_odd(Grid)              # one less if grids have odd # of latitude rings
     nlon_max = get_nlon_max(Grid,nresolution)       # number of longitudes around the equator
     nlon = nlon_max                                 # same (used for compatibility)
-    nside = Grid isa HEALPixGrid ? nresolution : 0  # nside is only defined for HEALPixGrid (npoints)
+    nside = (Grid isa HEALPixGrid || Grid isa HEALPix4Grid) ? nresolution : 0  # nside is only defined for HEALPixGrid or HEALPix4Grid (npoints)
     npoints = get_npoints(Grid,nresolution)         # total number of grid points
 
-    # LATITUDE VECTORS (based on Gaussian, equi-angle or HEALPix latitudes)
+    # LATITUDE VECTORS (based on Gaussian, equi-angle, HEALPix or HEALPix4 latitudes)
     colat = get_colat(Grid,nresolution)             # colatitude in radians
     lat = π/2 .- colat                              # latitude in radians
     colatd = colat*360/2π                           # and the same in degree 0...180˚

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -604,7 +604,7 @@ matrix_size(::Type{HEALPix4Grid},nside::Integer)=(2nside,2nside)
 Base.Matrix(G::HEALPix4Grid{T};kwargs...) where T = Matrix!(zeros(T,matrix_size(G)...),G;kwargs...)
 """
     Matrix!(M::AbstractMatrix,
-            G::OctahedralClenshawGrid;
+            G::HEALPix4Grid;
             quadrant_rotation=(0,1,2,3),
             matrix_quadrant=((2,2),(1,2),(1,1),(2,1)),
             )
@@ -615,7 +615,7 @@ Every quadrant of the grid `G` is rotated as specified in `quadrant_rotation`,
 eastward starting from 0˚E. The grid quadrants are moved into the matrix quadrant
 (i,j) as specified. Defaults are equivalent to centered at 0˚E and a rotation
 such that the North Pole is at M's midpoint."""
-Matrix!(M::AbstractMatrix,G::OctahedralClenshawGrid;kwargs...) = Matrix!((M,G);kwargs...)
+Matrix!(M::AbstractMatrix,G::HEALPix4Grid;kwargs...) = Matrix!((M,G);kwargs...)
 
 """
     Matrix!(MGs::Tuple{AbstractMatrix{T},HEALPix4Grid}...;kwargs...)

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -174,6 +174,68 @@ function each_index_in_ring(::Type{<:AbstractHEALPixGrid},  # function for HEALP
 end
 
 """
+    abstract type AbstractHEALPix4Grid{T} <: AbstractGrid{T} end
+
+An `AbstractHEALPix4Grid` is a horizontal grid similar to the standard OctahedralGrid,
+but the number of points in the ring closest to the Poles starts from 4 instead of 20,
+and the longitude of the first point in each ring is shifted as in HEALPixGrid.
+Also, different latitudes can be used."""
+abstract type AbstractHEALPix4Grid{T} <: AbstractGrid{T} end
+
+get_nresolution(G::AbstractHEALPix4Grid) = G.nside
+get_nlat_half(::Type{<:AbstractHEALPix4Grid},nside::Integer) = nside
+nlat_odd(::Type{<:AbstractHEALPix4Grid}) = true
+get_nlon_max(::Type{<:AbstractHEALPix4Grid},nside::Integer) = 4nside
+
+function get_nlon_per_ring(::Type{<:AbstractHEALPix4Grid},nside::Integer,j::Integer)
+    nlat = 2nside-1
+    @assert 0 < j <= nlat "Ring $j is outside J$nside grid."
+    nlat_half = (nlat+1)÷2
+    j = j > nlat_half ? nlat - j + 1 : j      # flip north south due to symmetry
+    return nlon_healpix4(nside,j)
+end
+
+get_npoints(::Type{<:AbstractHEALPix4Grid},nside::Integer) = npoints_healpix4(nside)
+get_lon(::Type{<:AbstractHEALPix4Grid},nside::Integer) = Float64[]    # only defined for full grids
+
+function get_colatlons(Grid::Type{<:AbstractHEALPix4Grid},nside::Integer)
+    npoints = get_npoints(Grid,nside)
+    colat = get_colat(Grid,nside)
+
+    colats = zeros(npoints)
+    lons = zeros(npoints)
+
+    ij = 1
+    for j in 1:2nside-1
+        nlon = get_nlon_per_ring(Grid,nside,j)
+        lon = collect(π/nlon:2π/nlon:2π)
+
+        colats[ij:ij+nlon-1] .= colat[j]
+        lons[ij:ij+nlon-1] .= lon
+
+        ij += nlon
+    end
+    return colats, lons
+end
+
+function each_index_in_ring(::Type{<:AbstractHEALPix4Grid}, # function for HEALPix4 grids
+                            j::Integer,                     # ring index north to south
+                            nside::Integer)                 # resolution param
+
+    @boundscheck 0 < j < 2nside || throw(BoundsError)       # ring index valid?
+    if j <= nside                                           # northern hemisphere incl Equator
+        index_1st = 2j*(j-1) + 1                            # first in-ring index i
+        index_end = 2j*(j+1)                                # last in-ring index i
+    else                                                    # southern hemisphere 
+        n = 4nside^2                                        # total number of points
+        j = 2nside - j                                      # count ring index from south pole
+        index_1st = n - 2j*(j+1) + 1                        # count backwards
+        index_end = n - 2j*(j-1)
+    end
+    return index_1st:index_end                              # range of i's in ring
+end
+
+"""
     G = FullClenshawGrid{T}
 
 A FullClenshawGrid is a regular latitude-longitude grid with an odd number of `nlat` equi-spaced
@@ -250,6 +312,43 @@ get_colat(::Type{<:FullGaussianGrid},nlat_half::Integer) =
 # each_index_in_ring() is already implemented for AbstractFullGrid
 get_quadrature_weights(::Type{<:FullGaussianGrid},nlat_half::Integer) = gaussian_weights(nlat_half)
 full_grid(::Type{<:FullGaussianGrid}) = FullGaussianGrid    # the full grid with same latitudes
+
+"""
+    G = FullHEALPix4Grid{T}
+
+A full HEALPix4 grid is a regular latitude-longitude grid that uses `nlat` HEALPix4 latitudes,
+and the same `nlon` longitudes for every latitude ring. The grid points are closer in zonal direction
+around the poles. The values of all grid points are stored in a vector field `v` that unravels
+the data 0 to 360˚, then ring by ring, which are sorted north to south."""
+struct FullHEALPix4Grid{T} <: AbstractFullGrid{T}
+    data::Vector{T}    # data vector, ring by ring, north to south
+    nlat_half::Int  # number of latitudes on one hemisphere
+
+    FullHEALPix4Grid{T}(data,nlat_half) where T = length(data) == npoints_fullhealpix4(nlat_half) ?
+    new(data,nlat_half) : error("$(length(data))-element Vector{$(eltype(data))} cannot be used to create a "*
+        "F$nlat_half ($(4nlat_half)x$(2nlat_half - 1)) FullHEALPix4Grid{$T}.")
+end
+npoints_fullhealpix4(nlat_half::Integer) = 8nlat_half^2 - 4nlat_half
+nlat_half_fullhealpix4(npoints::Integer) = round(Int,1/4 + sqrt(1/16 + npoints/8))
+
+# infer nlat_half from data vector length, infer parametric type from eltype of data
+FullHEALPix4Grid{T}(data::AbstractVector) where T = FullHEALPix4Grid{T}(data,nlat_half_fullhealpix4(length(data)))
+FullHEALPix4Grid(data::AbstractVector,n::Integer...) = FullHEALPix4Grid{eltype(data)}(data,n...)
+
+truncation_order(::Type{<:FullHEALPix4Grid}) = 3            # cubic
+get_truncation(::Type{<:FullHEALPix4Grid},nlat_half::Integer) = floor(Int,(4nlat_half-1)/4)
+get_resolution(::Type{<:FullHEALPix4Grid},trunc::Integer) = roundup_fft(ceil(Int,(4*trunc+1)/4))
+# get_nresolution() is already defined for AbstractFullGrid
+nlat_odd(::Type{<:FullHEALPix4Grid}) = true
+# get_nlon() is already implemented for AbstractFullGrid
+# get_nlon_per_ring() is already implemented for AbstractFullGrid
+get_npoints(::Type{<:FullHEALPix4Grid},nlat_half::Integer) = npoints_fullhealpix4(nlat_half)
+get_colat(::Type{<:FullHEALPix4Grid},nlat_half::Integer) = get_colat(HEALPix4Grid,nlat_half)
+# get_lon() is already implemented for AbstractFullGrid
+# get_colatlons() is already implemented for AbstractFullGrid
+# each_index_in_ring() is already implemented for AbstractFullGrid
+get_quadrature_weights(::Type{<:FullHEALPix4Grid},nlat_half::Integer) = healpix4_weights(nlat_half)
+full_grid(::Type{<:FullHEALPix4Grid}) = FullHEALPix4Grid    # the full grid with same latitudes
 
 """
     G = OctahedralGaussianGrid{T}
@@ -466,6 +565,126 @@ get_colat(G::Type{<:HEALPixGrid},nside::Integer) =
 full_grid(::Type{<:HEALPixGrid}) = FullHEALPixGrid    # the full grid with same latitudes
 matrix_size(G::HEALPixGrid) = (5G.nside,5G.nside)
 
+"""
+    J = HEALPix4Grid{T}
+
+A HEALPix4 grid with 4 base faces, each `nside`x`nside` grid points, each covering the same area.
+The values of all grid points are stored in a vector field `v` that unravels the data 0 to 360˚,
+then ring by ring, which are sorted north to south."""
+struct HEALPix4Grid{T} <: AbstractHEALPix4Grid{T}
+    data::Vector{T}    # data vector, ring by ring, north to south
+    nside::Int      # nside^2 is the number of pixel in each of the 12 base pixel
+
+    HEALPix4Grid{T}(data,nside) where T = length(data) == npoints_healpix4(nside) ?
+    new(data,nside) : error("$(length(data))-element Vector{$(eltype(data))}"*
+    "cannot be used to create an J$nside HEALPix4Grid{$T}.")
+end
+
+npoints_healpix4(nside::Integer) = 4nside^2
+nside_healpix4(npoints::Integer) = round(Int,sqrt(npoints/4))  # inverse of npoints_healpix4
+nlat_healpix4(nside::Integer) = 2nside-1
+nlon_healpix4(nside::Integer,j::Integer) = 4j
+
+# infer nside from data vector length, infer parametric type from eltype of data
+HEALPix4Grid{T}(data::AbstractVector) where T = HEALPix4Grid{T}(data,nside_healpix4(length(data)))
+HEALPix4Grid(data::AbstractVector,n::Integer...) = HEALPix4Grid{eltype(data)}(data,n...)
+
+truncation_order(::Type{<:HEALPix4Grid}) = 3                 # cubic (in longitude)
+get_truncation(::Type{<:HEALPix4Grid},nside::Integer) = nside-1
+get_resolution(::Type{<:HEALPix4Grid},trunc::Integer) = roundup_fft(trunc+1)
+get_colat(G::Type{<:HEALPix4Grid},nside::Integer) =
+    ( colat_half=[acos(1-(j/nside)^2) for j in 1:nside]; vcat(colat_half,π.-colat_half[end-1:-1:1]) )
+# get_lon() is already implemented for AbstractHEALPix4Grid
+# get_colatlons() is already implemented for AbstractHEALPix4Grid
+# each_index_in_ring() is already implemented for AbstractHEALPix4Grid
+full_grid(::Type{<:HEALPix4Grid}) = FullHEALPix4Grid    # the full grid with same latitudes
+
+matrix_size(G::HEALPix4Grid) = (2G.nside,2G.nside)
+matrix_size(::Type{HEALPix4Grid},nside::Integer)=(2nside,2nside)
+Base.Matrix(G::HEALPix4Grid{T};kwargs...) where T = Matrix!(zeros(T,matrix_size(G)...),G;kwargs...)
+"""
+    Matrix!(M::AbstractMatrix,
+            G::OctahedralClenshawGrid;
+            quadrant_rotation=(0,1,2,3),
+            matrix_quadrant=((2,2),(1,2),(1,1),(2,1)),
+            )
+
+Sorts the gridpoints in `G` into the matrix `M` without interpolation.
+Every quadrant of the grid `G` is rotated as specified in `quadrant_rotation`,
+0 is no rotation, 1 is 90˚ clockwise, 2 is 180˚ etc. Grid quadrants are counted
+eastward starting from 0˚E. The grid quadrants are moved into the matrix quadrant
+(i,j) as specified. Defaults are equivalent to centered at 0˚E and a rotation
+such that the North Pole is at M's midpoint."""
+Matrix!(M::AbstractMatrix,G::OctahedralClenshawGrid;kwargs...) = Matrix!((M,G);kwargs...)
+
+"""
+    Matrix!(MGs::Tuple{AbstractMatrix{T},HEALPix4Grid}...;kwargs...)
+
+Like `Matrix!(::AbstractMatrix,::HEALPix4Grid)` but for simultaneous
+processing of tuples `((M1,G1),(M2,G2),...)` with matrices `Mi` and grids `Gi`.
+All matrices and grids have to be of the same size respectively."""
+function Matrix!(   MGs::Tuple{AbstractMatrix{T},HEALPix4Grid}...;
+                    quadrant_rotation::NTuple{4,Integer}=(0,1,2,3),     # = 0˚, 90˚, 180˚, 270˚ anti-clockwise
+                    matrix_quadrant::NTuple{4,Tuple{Integer,Integer}}=((2,2),(1,2),(1,1),(2,1)),
+                    ) where T
+                    
+    ntuples = length(MGs)
+
+    # check that the first (matrix,grid) tuple has corresponding sizes
+    M,G = MGs[1]
+    m,n = size(M)
+    @boundscheck m == n || throw(BoundsError)
+    @boundscheck m == 2*G.nside || throw(BoundsError)
+
+    for MG in MGs   # check that all matrices and all grids are of same size
+        Mi,Gi = MG
+        @boundscheck size(Mi) == size(M) || throw(BoundsError)
+        @boundscheck size(Gi) == size(G) || throw(BoundsError)
+    end
+
+    for q in matrix_quadrant    # check always in 2x2
+        sr,sc = q
+        @boundscheck ((sr in (1,2)) && (sc in (1,2))) || throw(BoundsError)
+    end
+
+    rings = eachring(G)         # index ranges for all rings
+    nlat_half = G.nside         # number of latitude rings on one hemisphere incl Equator
+    nside = G.nside           # side length of a basepixel matrix (=nside in HEALPix)
+
+    # sort grid indices from G into matrix M
+    # 1) loop over each grid point per ring
+    # 2) determine quadrant (0,1,2,3) via modulo
+    # 3) get longitude index iq within quadrant
+    # 4) determine corresponding indices r,c in matrix M
+
+    @inbounds for (j,ring) in enumerate(rings)
+        nlon = length(ring)                         # number of grid points in ring
+        for ij in ring                              # continuous index in grid
+            i = ij-ring[1]                          # 0-based index in ring
+            grid_quadrant = floor(Int,mod(4*i/nlon,4))  # either 0,1,2,3
+            iq = i - grid_quadrant*(nlon÷4)             # 0-based index i relative to quadrant
+            r = min(j,nlat_half) - iq             # row in matrix m (1-based)
+            c = (iq+1) + max(0,j-nlat_half)         # column in matrix m (1-based)
+
+            # rotate indices in quadrant
+            r,c = rotate_matrix_indices(r,c,nside,quadrant_rotation[grid_quadrant+1])
+
+            # shift grid quadrant to matrix quadrant
+            sr,sc = matrix_quadrant[grid_quadrant+1]
+            r += (sr-1)*nside                       # shift row into matrix quadrant
+            c += (sc-1)*nside                       # shift column into matrix quadrant
+
+            for (Mi,Gi) in MGs                      # for every (matrix,grid) tuple
+                Mi[r,c] = convert(T,Gi[ij])         # convert data and copy over
+            end
+        end
+    end
+
+    ntuples == 1 && return M
+    return Tuple(Mi for (Mi,Gi) in MGs)
+end
+
+
 # QUADRATURE WEIGHTS
 # gaussian_weights are exact for Gaussian latitudes when nlat > (2T+1)/2
 # clenshaw_curtis_weights are exact for equi-angle latitudes when nlat > 2T+1
@@ -475,9 +694,15 @@ function clenshaw_curtis_weights(nlat_half::Integer)
     θs = get_colat(FullClenshawGrid,nlat_half)
     return [4sin(θj)/(nlat+1)*sum([sin(p*θj)/p for p in 1:2:nlat]) for θj in θs[1:nlat_half]]
 end
+healpix_weights(nside::Integer) =
+    [nlon_healpix(nside,j) for j in 1:2nside].*(2/npoints_healpix(nside))
+healpix4_weights(nside::Integer) =
+    [nlon_healpix4(nside,j) for j in 1:nside].*(2/npoints_healpix4(nside))
 
 # SOLID ANGLES ΔΩ = sinθ Δθ Δϕ
 get_solid_angles(Grid::Type{<:AbstractGrid},nlat_half::Integer) = 
     get_quadrature_weights(Grid,nlat_half) .* (2π./get_nlons(Grid,nlat_half))
 get_solid_angles(Grid::Type{<:HEALPixGrid},nside::Integer) =
+    4π/get_npoints(Grid,nside)*ones(get_nlat_half(Grid,nside))
+get_solid_angles(Grid::Type{<:HEALPix4Grid},nside::Integer) =
     4π/get_npoints(Grid,nside)*ones(get_nlat_half(Grid,nside))

--- a/src/spectral_transform.jl
+++ b/src/spectral_transform.jl
@@ -83,14 +83,14 @@ function SpectralTransform( ::Type{NF},                     # Number format NF
 
     # RESOLUTION PARAMETERS
     nresolution = get_resolution(Grid,trunc)        # resolution parameter, nlat_half/nside for HEALPixGrid
-    nlat_half = get_nlat_half(Grid,nresolution)     # contains equator for HEALPix
+    nlat_half = get_nlat_half(Grid,nresolution)     # contains equator for HEALPix, HEALPix4 and Clenshaw
     nlat = 2nlat_half - nlat_odd(Grid)              # one less if grids have odd # of latitude rings
     nlon_max = get_nlon_max(Grid,nresolution)       # number of longitudes around the equator
                                                     # number of longitudes per latitude ring (one hemisphere only)
     nlons = [get_nlon_per_ring(Grid,nresolution,j) for j in 1:nlat_half]
     nfreq_max = nlon_max÷2 + 1                      # maximum number of fourier frequencies (real FFTs)
 
-    # LATITUDE VECTORS (based on Gaussian, equi-angle or HEALPix latitudes)
+    # LATITUDE VECTORS (based on Gaussian, equi-angle HEALPix or HEALPix4 latitudes)
     colat = get_colat(Grid,nresolution)             # colatitude in radians                             
     cos_colat = cos.(colat)                         # cos(colat)
     sin_colat = sin.(colat)                         # sin(colat)
@@ -108,6 +108,7 @@ function SpectralTransform( ::Type{NF},                     # Number format NF
     lon1s = [lons[each_index_in_ring(Grid,j,nresolution)[1]] for j in 1:nlat_half]
     lon_offsets = [cispi(m*lon1/π) for m in 0:mmax, lon1 in lon1s]
     Grid <: AbstractHEALPixGrid && fill!(lon_offsets,1)     # no rotation for HEALPix at the moment
+    Grid <: AbstractHEALPix4Grid && fill!(lon_offsets,1)    # no rotation for HEALPix4 at the moment
     
     # PREALLOCATE LEGENDRE POLYNOMIALS, lmax+2 for one more degree l for meridional gradient recursion
     Λ = zeros(LowerTriangularMatrix{NF},lmax+2,mmax+1)  # Legendre polynomials for one latitude

--- a/test/grids.jl
+++ b/test/grids.jl
@@ -7,6 +7,8 @@
         O = OctahedralGaussianGrid(randn(NF,3168),24)   # O24 grid
         C = OctahedralClenshawGrid(randn(NF,3056),24)   # C24 grid
         H = HEALPixGrid(randn(NF,3072),16)              # H16 grid
+        J = HEALPix4Grid(randn(NF,1024),16)             # J16 grid
+        K = FullHEALPix4Grid(randn(NF,64*31),16)        # K16 grid
 
         # without resolution parameter provided (inferred from vector length)
         L2 = FullClenshawGrid(randn(NF,96*47))          # L24 grid
@@ -14,8 +16,10 @@
         O2 = OctahedralGaussianGrid(randn(NF,3168))     # O24 grid
         C2 = OctahedralClenshawGrid(randn(NF,3056))     # C24 grid
         H2 = HEALPixGrid(randn(NF,3072))                # H16 grid
+        J2 = HEALPix4Grid(randn(NF,1024))               # J16 grid
+        K2 = FullHEALPix4Grid(randn(NF,64*31))          # K16 grid
 
-        for (grid1,grid2) in zip([L,F,O,C,H],[L2,F2,O2,C2,H2])
+        for (grid1,grid2) in zip([L,F,O,C,H,J,K],[L2,F2,O2,C2,H2,J2,K2])
             @test size(grid1) == size(grid2)
         end
 
@@ -25,6 +29,8 @@
         for ij in eachindex(O) O[ij] end
         for ij in eachindex(C) C[ij] end
         for ij in eachindex(H) H[ij] end
+        for ij in eachindex(J) J[ij] end
+        for ij in eachindex(K) K[ij] end
 
         # set index
         for ij in eachindex(L) L[ij] = 0 end
@@ -32,12 +38,16 @@
         for ij in eachindex(O) O[ij] = 0 end
         for ij in eachindex(C) C[ij] = 0 end
         for ij in eachindex(H) H[ij] = 0 end
+        for ij in eachindex(J) J[ij] = 0 end
+        for ij in eachindex(K) K[ij] = 0 end
 
         @test all(L .== 0)
         @test all(F .== 0)
         @test all(O .== 0)
         @test all(C .== 0)
         @test all(H .== 0)
+        @test all(J .== 0)
+        @test all(K .== 0)
     end
 end
 
@@ -48,6 +58,8 @@ end
                     OctahedralGaussianGrid,
                     OctahedralClenshawGrid,
                     HEALPixGrid,
+                    HEALPix4Grid,
+                    FullHEALPix4Grid
                     )
 
             n = 32      # resolution parameter nlat_half/nside
@@ -75,6 +87,8 @@ end
                 OctahedralGaussianGrid,
                 OctahedralClenshawGrid,
                 HEALPixGrid,
+                HEALPix4Grid,
+                FullHEALPix4Grid
                 )
 
         n = 32      # resolution parameter nlat_half/nside


### PR DESCRIPTION
@milankl  As I promised before, I implemented HEALPix4 grid that we proposed in issue #112 (along with its FullGrid version).
Note, however, that, like our current HEALPixGrid implementation, zonal shifts of the first points on each latitude ring is not turned on yet.

This pull request should pass all the tests in test/runtests.jl.

Results of 10-day integrations visually look very similar to the established OctahedralGaussianGrid.

![10day-iteg-OctahedralGaussian-HEALPix](https://user-images.githubusercontent.com/88590419/193844593-1d9650a0-b038-4e01-95c6-bd20b3af7470.png)
![10day-iteg-HEALPix4-FullHEALPix4](https://user-images.githubusercontent.com/88590419/193844678-fccb9295-c81c-43bf-858c-cc688b23474d.png)

I also did some convergence assessment of transform errors by comparing spectral coefficients before and after round-trip transforms. Results attached below:
Double precision:
 ![transform_convergence_dp](https://user-images.githubusercontent.com/88590419/193843822-25a5ce84-0f60-4671-9c56-87b809f997b4.png)
Single precision:
![transform_convergence_sp](https://user-images.githubusercontent.com/88590419/193843846-effcc3b4-f96c-4f3b-b19d-6fc9d90347c7.png)

From these I believe HEALPix4 is at least as accurate as HEALPix.