### PR TITLE
LowerTriangularMatrix Broadcast fix

### DIFF
--- a/src/lower_triangular_matrix.jl
+++ b/src/lower_triangular_matrix.jl
@@ -264,6 +264,7 @@ function Base.:(-)(L1::LowerTriangularMatrix,L2::LowerTriangularMatrix)
 end
 
 Base.:(-)(L::LowerTriangularMatrix) = LowerTriangularMatrix(-L.data,size(L)...)
+Base.prod(L::LowerTriangularMatrix{NF}) where NF = zero(T)
 
 """
     fill!(L::LowerTriangularMatrix,x)

--- a/src/lower_triangular_matrix.jl
+++ b/src/lower_triangular_matrix.jl
@@ -309,9 +309,13 @@ LowerTriangularStyle(::Val{2}) = LowerTriangularStyle()
 function Base.copyto!(dest::LowerTriangularMatrix{T}, bc::Broadcasted{<:LowerTriangularStyle}) where T
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    for i in axs[1]
-        for j in 1:i
-            dest.data[ij2k(i,j,dest.m)] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, j))
+
+    lmax,mmax = size(dest)
+    lm = 0
+    for m in 1:mmax
+        for l in m:lmax
+            lm += 1
+            dest.data[lm] = Broadcast._broadcast_getindex(bc, CartesianIndex(l, m))
         end
     end
     return dest
@@ -319,3 +323,4 @@ end
 
 # GPU methods
 Adapt.adapt_structure(to, x::LowerTriangularMatrix{T}) where T = LowerTriangularMatrix(Adapt.adapt(to, x.data), x.m, x.n)
+

--- a/src/lower_triangular_matrix.jl
+++ b/src/lower_triangular_matrix.jl
@@ -184,8 +184,8 @@ function Base.copyto!(  L::LowerTriangularMatrix{T},    # copy to L
     L
 end
 
-function Base.copyto!(  M::AbstractMatrix{T},               # copy to L
-                        L::LowerTriangularMatrix) where T   # copy from M
+function Base.copyto!(  M::AbstractMatrix{T},               # copy to M
+                        L::LowerTriangularMatrix) where T   # copy from L
 
     @boundscheck size(L) == size(M) || throw(BoundsError)
     lmax,mmax = size(L)
@@ -201,7 +201,7 @@ function Base.copyto!(  M::AbstractMatrix{T},               # copy to L
             M[l,m] = convert(T,M[lm])
         end
     end
-    L
+    M
 end
 
 function LowerTriangularMatrix{T}(M::LowerTriangularMatrix) where T

--- a/src/lower_triangular_matrix.jl
+++ b/src/lower_triangular_matrix.jl
@@ -264,7 +264,7 @@ function Base.:(-)(L1::LowerTriangularMatrix,L2::LowerTriangularMatrix)
 end
 
 Base.:(-)(L::LowerTriangularMatrix) = LowerTriangularMatrix(-L.data,size(L)...)
-Base.prod(L::LowerTriangularMatrix{NF}) where NF = zero(T)
+Base.prod(L::LowerTriangularMatrix{NF}) where NF = zero(NF)
 
 """
     fill!(L::LowerTriangularMatrix,x)

--- a/test/lower_triangular_matrix.jl
+++ b/test/lower_triangular_matrix.jl
@@ -115,5 +115,11 @@ end
 
         L2 ./= NF(5)
         @test L1 ./ NF(5) ≈ L2 
+
+        L1 = randn(LowerTriangularMatrix{NF},10,10)
+        L2 = copy(L1)
+
+        L2 .^= NF(2)
+        @test L1 .^ NF(2) ≈ L2
     end
 end 

--- a/test/lower_triangular_matrix.jl
+++ b/test/lower_triangular_matrix.jl
@@ -101,3 +101,19 @@ end
         @test L2 == L2c
     end
 end
+
+@testset "LowerTriangularMatrix: broadcast" begin 
+    @testset for NF in (Float16,Float32,Float64)
+        L1 = randn(LowerTriangularMatrix{NF},10,10)
+        L2 = copy(L1) 
+
+        L2 .*= NF(5)
+        @test L1 .* NF(5) ≈ L2 
+
+        L1 = randn(LowerTriangularMatrix{NF},10,10)
+        L2 = copy(L1) 
+
+        L2 ./= NF(5)
+        @test L1 ./ NF(5) ≈ L2 
+    end
+end 


### PR DESCRIPTION
I lied. I didn't give up. 

I found some code in LinearAlgebra.jl that was helpful. 

However, there's still an error in this draft. I doesn't work for non-square matrices. It's about the indexing in the `copyto!` function. That's definitely fixeable. I didn't want to do a "hacky" solution in which I distinguish between square matrices and those with an added row, it would be nicer to have something more elegant and general.