### PR TITLE
Legendre shortcut: truncate loop over m

### DIFF
--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -100,7 +100,7 @@ The default values of the keywords define the default model setup.
     # LEGENDRE TRANSFORM AND POLYNOMIALS
     recompute_legendre::Bool = false    # recomputation is slower but requires less memory
     legendre_NF::DataType = Float64     # which format to use to calculate the Legendre polynomials
-    legendre_shortcut::Symbol = :linear
+    legendre_shortcut::Symbol = :linear # :linear, :quadratic, :cubic, :lincub_coslat, :linquad_coslat²
 
     # BOUNDARY FILES
     boundary_path::String = ""          # package location is default

--- a/src/spectral_transform.jl
+++ b/src/spectral_transform.jl
@@ -14,6 +14,7 @@ struct SpectralTransform{NF<:AbstractFloat}
     lmax::Int               # Maximum degree l=[0,lmax] of spherical harmonics
     mmax::Int               # Maximum order m=[0,l] of spherical harmonics
     nfreq_max::Int          # Maximum (at Equator) number of Fourier frequencies (real FFT)
+    m_truncs::Vector{Int}   # Maximum order m to retain per latitude ring
 
     # CORRESPONDING GRID SIZE
     nlon_max::Int           # Maximum number of longitude points (at Equator)
@@ -74,7 +75,9 @@ and preallocates the Legendre polynomials (if recompute_legendre == false) and q
 function SpectralTransform( ::Type{NF},                     # Number format NF
                             Grid::Type{<:AbstractGrid},     # type of spatial grid used
                             trunc::Int,                     # Spectral truncation
-                            recompute_legendre::Bool) where NF
+                            recompute_legendre::Bool;       # re or precompute legendre polynomials?
+                            legendre_shortcut::Symbol=:linear   # shorten Legendre loop over order m
+                            ) where NF
 
     # SPECTRAL RESOLUTION
     lmax = trunc                # Maximum degree l=[0,lmax] of spherical harmonics
@@ -94,6 +97,19 @@ function SpectralTransform( ::Type{NF},                     # Number format NF
     colat = get_colat(Grid,nlat_half)               # colatitude in radians                             
     cos_colat = cos.(colat)                         # cos(colat)
     sin_colat = sin.(colat)                         # sin(colat)
+
+    # LEGENDRE SHORTCUT OVER ORDER M (to have linear/quad/cubic truncation per latitude ring)
+    if legendre_shortcut in (:linear,:quadratic,:cubic)
+        s = (linear=1,quadratic=2,cubic=3)[legendre_shortcut]
+        m_truncs = [nlons[j]÷(s+1) + 1 for j in 1:nlat_half]
+    elseif legendre_shortcut == :linquad_coslat²
+        m_truncs = [floor(Int,(nlons[j] - 1)/(2 + sin_colat[j]^2)) - 1 for j in 1:nlat_half]
+    elseif legendre_shortcut == :lincub_coslat
+        m_truncs = [ceil(Int,nlons[j]/(2 + 2sin_colat[j])) for j in 1:nlat_half]
+    else
+        throw(error("legendre_shortcut=$legendre_shortcut not defined."))
+    end
+    m_truncs = min.(m_truncs,mmax+1)    # only to mmax in any case (otherwise BoundsError)
 
     # PLAN THE FFTs
     FFT_package = NF <: Union{Float32,Float64} ? FFTW : GenericFFT
@@ -185,7 +201,7 @@ function SpectralTransform( ::Type{NF},                     # Number format NF
 
     # conversion to NF happens here
     SpectralTransform{NF}(  Grid,nresolution,order,
-                            lmax,mmax,nfreq_max,
+                            lmax,mmax,nfreq_max,m_truncs,
                             nlon_max,nlons,nlat,nlat_half,
                             colat,cos_colat,sin_colat,lon_offsets,
                             norm_sphere,
@@ -216,6 +232,8 @@ function spectral_transform_for_full_grid(S::SpectralTransform{NF}) where NF
 
     # recalculate what changes on the full grid: FFT and offsets (always 1)
     nlons = [get_nlon_per_ring(FullGrid,nlat_half,j) for j in 1:nlat_half]
+    m_truncs = [mmax+1 for _ in 1:nlat_half]    # no Legendre shortcut for full grids
+
     FFT_package = NF <: Union{Float32,Float64} ? FFTW : GenericFFT
     rfft_plans = [FFT_package.plan_rfft(zeros(NF,nlon)) for nlon in nlons]
     brfft_plans = [FFT_package.plan_brfft(zeros(Complex{NF},nlon÷2 + 1),nlon) for nlon in nlons]
@@ -226,7 +244,7 @@ function spectral_transform_for_full_grid(S::SpectralTransform{NF}) where NF
     solid_angles = get_solid_angles(FullGrid,nlat_half)
 
     return SpectralTransform{NF}(   FullGrid,nresolution,order,
-                                    lmax,mmax,nfreq_max,
+                                    lmax,mmax,nfreq_max,m_truncs,
                                     nlon_max,nlons,nlat,nlat_half,
                                     colat,cos_colat,sin_colat,lon_offsets,
                                     norm_sphere,
@@ -243,8 +261,8 @@ end
 
 Generator function for a SpectralTransform struct pulling in parameters from a Parameters struct."""
 function SpectralTransform(P::Parameters)
-    @unpack NF, Grid, trunc, recompute_legendre = P
-    return SpectralTransform(NF,Grid,trunc,recompute_legendre)
+    @unpack NF, Grid, trunc, recompute_legendre, legendre_shortcut = P
+    return SpectralTransform(NF,Grid,trunc,recompute_legendre;legendre_shortcut)
 end
 
 """
@@ -344,7 +362,7 @@ function gridded!(  map::AbstractGrid{NF},                      # gridded output
 
     @unpack nlat, nlons, nlat_half, nfreq_max, order = S
     @unpack cos_colat, sin_colat, lon_offsets = S
-    @unpack recompute_legendre, Λ, Λs = S
+    @unpack recompute_legendre, Λ, Λs, m_truncs = S
     @unpack brfft_plans = S
 
     recompute_legendre && @boundscheck size(alms) == size(Λ) || throw(BoundsError)
@@ -366,7 +384,7 @@ function gridded!(  map::AbstractGrid{NF},                      # gridded output
         j_south = nlat - j_north + 1        # southern latitude index
         nlon = nlons[j_north]               # number of longitudes on this ring
         nfreq  = nlon÷2 + 1                 # linear max Fourier frequency wrt to nlon
-        nfreqm = nlon÷(order+1) + 1         # (lin/quad/cub) max frequency to shorten loop over m
+        m_trunc = m_truncs[j_north]         # (lin/quad/cub) max frequency to shorten loop over m
         not_equator = j_north != j_south    # is the latitude ring not on equator?
 
         # Recalculate or use precomputed Legendre polynomials Λ
@@ -375,7 +393,7 @@ function gridded!(  map::AbstractGrid{NF},                      # gridded output
 
         # inverse Legendre transform by looping over wavenumbers l,m
         lm = 1                              # single index for non-zero l,m indices
-        for m in 1:min(nfreq,mmax+1)        # Σ_{m=0}^{mmax}, but 1-based index
+        for m in 1:m_trunc                  # Σ_{m=0}^{mmax}, but 1-based index, shortened to m_trunc
             acc_odd  = zero(Complex{NF})    # accumulator for isodd(l+m)
             acc_even = zero(Complex{NF})    # accumulator for iseven(l+m)
 
@@ -450,7 +468,7 @@ function spectral!( alms::LowerTriangularMatrix{Complex{NF}},   # output: spectr
     
     @unpack nlat, nlat_half, nlons, nfreq_max, order, cos_colat = S
     @unpack recompute_legendre, Λ, Λs, solid_angles = S
-    @unpack rfft_plans, lon_offsets = S
+    @unpack rfft_plans, lon_offsets, m_truncs = S
     
     recompute_legendre && @boundscheck size(alms) == size(Λ) || throw(BoundsError)
     recompute_legendre || @boundscheck size(alms) == size(Λs[1]) || throw(BoundsError)
@@ -474,7 +492,7 @@ function spectral!( alms::LowerTriangularMatrix{Complex{NF}},   # output: spectr
         j_south = nlat - j_north + 1        # corresponding southern latitude index
         nlon = nlons[j_north]               # number of longitudes on this ring
         nfreq  = nlon÷2 + 1                 # linear max Fourier frequency wrt to nlon
-        nfreqm = nlon÷(order+1) + 1         # (lin/quad/cub) max frequency to shorten loop over m
+        m_trunc = m_truncs[j_north]         # (lin/quad/cub) max frequency to shorten loop over m
         not_equator = j_north != j_south    # is the latitude ring not on equator?
 
         # FOURIER TRANSFORM in zonal direction
@@ -496,7 +514,7 @@ function spectral!( alms::LowerTriangularMatrix{Complex{NF}},   # output: spectr
         ΔΩ = solid_angles[j_north]                      # = sinθ Δθ Δϕ, solid angle for a grid point
 
         lm = 1                                          # single index for spherical harmonics
-        for m in 1:min(nfreq,mmax+1)              # Σ_{m=0}^{mmax}, but 1-based index
+        for m in 1:m_trunc                              # Σ_{m=0}^{mmax}, but 1-based index
 
             an, as = fn[m], fs[m]
 

--- a/src/spectral_transform.jl
+++ b/src/spectral_transform.jl
@@ -103,7 +103,7 @@ function SpectralTransform( ::Type{NF},                     # Number format NF
         s = (linear=1,quadratic=2,cubic=3)[legendre_shortcut]
         m_truncs = [nlons[j]÷(s+1) + 1 for j in 1:nlat_half]
     elseif legendre_shortcut == :linquad_coslat²
-        m_truncs = [floor(Int,(nlons[j] - 1)/(2 + sin_colat[j]^2)) - 1 for j in 1:nlat_half]
+        m_truncs = [ceil(Int,nlons[j]/(2 + sin_colat[j]^2)) for j in 1:nlat_half]
     elseif legendre_shortcut == :lincub_coslat
         m_truncs = [ceil(Int,nlons[j]/(2 + 2sin_colat[j])) for j in 1:nlat_half]
     else


### PR DESCRIPTION
fixes #131 

@hottad, this pull request now implements the various shortcuts over order $m$ in the Legendre Transform as discussed. I don't plan to change the default that is currently `run_speedy(legendre_shortcut=:linear)`, but as they are now implemented we can test them. The `m_truncs` (the maximum m per latitude ring) are now a field in `SpectralTransform`, which can be obtained like this
```julia
julia> P = Parameters(NF=Float64,Grid=OctahedralClenshawGrid);

julia> SpectralTransform(P).m_truncs
32-element Vector{Int64}:
 11
 13
 15
 17
 19
 21
 23
 25
 27
 29
 31
 32
 32
 32
 32
 32
 32
 32
 32
 32
 32
 32
 32
 32
 32
 32
 32
 32
 32
 32
 32
 32
```
and similar for `legendre_short` set to `:linear`,`:quadratic`,`:cubic`,`:linquad_coslat²`, `:lincub_coslat`, which are the options we discussed basically. (Did I miss the `m_to_retain` option or how different was that from `:linquad_coslat²`?)