### PR TITLE
[LowerTriangularMatrices] Sum for LTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug, so that sum now works for LowerTraingularArrays [#668](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/668)
 - Require only AbstractVectors in the interpolation [#665](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/665)
 - Intitialize! simulation restructured [#666](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/666)
 - First time steps in main time loop [#659](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/659)

--- a/docs/src/lowertriangularmatrices.md
+++ b/docs/src/lowertriangularmatrices.md
@@ -218,6 +218,13 @@ vector operations like a scalar product between two "LowerTriangularMatrix" vect
 L' * L
 ```
 
+Summation with `sum` follows the flat, single index logic
+```@repl 
+L = rand(LowerTriangularMatrix{Float32}, 3, 3, 5)
+sum(L, dims=2) 
+```
+sums along the second dimension of the underlying vector, not of the full matrix representation. 
+
 ## Broadcasting with `LowerTriangularArray`
 
 In contrast to linear algebra, many element-wise operations work as expected thanks to broadcasting,

--- a/src/LowerTriangularMatrices/lower_triangular_array.jl
+++ b/src/LowerTriangularMatrices/lower_triangular_array.jl
@@ -552,6 +552,7 @@ Base.similar(L::LowerTriangularArray{T, N, ArrayType}, ::Type{T}) where {T, N, A
 Base.similar(L::LowerTriangularArray{T}) where T = similar(L, T)
  
 Base.prod(L::LowerTriangularArray{NF}) where NF = zero(NF)
+@inline Base.sum(L::LowerTriangularArray; dims=:, kw...) = sum(L.data; dims, kw...)
 
 """
 $(TYPEDSIGNATURES)

--- a/test/lower_triangular_matrix.jl
+++ b/test/lower_triangular_matrix.jl
@@ -436,6 +436,15 @@ end
     end
 end
 
+@testset "LowerTriangularArray: sum" begin 
+    @testset for idims = ((5,), (5,5))
+        L = randn(LowerTriangularArray{Float32}, 3, 3, idims...)
+    
+        @test sum(L, dims=1) == sum(L.data, dims=1)
+        @test sum(L, dims=2) == sum(L.data, dims=2)
+    end 
+end 
+
 @testset "LowerTriangularMatrix: copyto!" begin
     @testset for NF in (Float16, Float32, Float64)
         L1 = randn(LowerTriangularMatrix{NF}, 10, 10)


### PR DESCRIPTION
As discussed in #602 and #558 

This adds `sum` for `LowerTriangularArrays`. It just forwards it to `sum(L.data)`. This means it follows the flat indexing dimension logic. I think this is the most consistent with our treatment of `LowerTriangularArrays` and how we also describe it in the docs. It also is by far the easies version to implement for `sum`. 

I didn't do a version for `cat` yet, as it is actually quite hard to do one that is reasonable performant and general at the same time. E.g. `cat([L.data for L in Ls]...)` would be quite poor due to the splatting. 