### PR TITLE
Extended tests launched on comment on PR branch

### DIFF
--- a/.github/workflows/extended_tests_on_comment.yml
+++ b/.github/workflows/extended_tests_on_comment.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/extended-tests')
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/extended-tests') && contains(github.event.comment.author_association,'OWNER')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -17,7 +17,13 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v4
+      - name: Get PR branch
+        uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+      - name: Checkout PR branch 
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/extended_tests_on_comment.yml
+++ b/.github/workflows/extended_tests_on_comment.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/extended-tests') && contains(github.event.comment.author_association,'OWNER')
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/extended-tests') && contains(github.event.comment.author_association,'MEMBER')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Extended CI tests can be launched on comment in PRs [#695](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/695)
+- Extended CI tests can be launched on comment in PRs [#695](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/695)[#696](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/696)
 - Reverse for AbstractGridArrays [#691](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/691)
 - LandGeometry, LandThermodynamics as component of LandModel, DryLandModel [#677](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/677)
 - Diagnostic albedo separate for ocean/land [#677](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/677)

--- a/test/differentiability/barotropic.jl
+++ b/test/differentiability/barotropic.jl
@@ -39,7 +39,7 @@
     @test isapprox(to_vec(fd_vjp[1])[1], to_vec(d_progn)[1], rtol=0.05) # we have to go really quite low with the tolerances here
     @test mean(abs.(to_vec(fd_vjp[1])[1] - to_vec(d_progn)[1])) < 0.002 # so we check a few extra statistics
     @test maximum(to_vec(fd_vjp[1].vor)[1] - to_vec(d_progn.vor)[1]) < 0.05
-    
+
     #
     # We go individually through all components of the time stepping and check 
     # correctness
@@ -141,7 +141,7 @@
 
     fd_vjp = FiniteDifferences.j′vp(central_fdm(5,1), x -> leapfrog_step(prog_new, progn_copy, x, dt, lf1, model), dprogn_copy, tend_copy)
 
-    @test all(isapprox.(to_vec(fd_vjp[1])[1], to_vec(dtend)[1],rtol=1e-5,atol=1e-5))
+    @test all(isapprox.(to_vec(fd_vjp[1])[1], to_vec(dtend)[1],rtol=1e-3,atol=1e-3))
 
     # 
     # single variable leapfrog step 
@@ -190,7 +190,7 @@
 
     fd_vjp = FiniteDifferences.j′vp(central_fdm(5,1), x -> transform_diagn(diag_copy, x, lf2, model), ddiag_copy, progn_copy)
     
-    @test all(isapprox.(to_vec(fd_vjp[1])[1], to_vec(dprogn)[1],rtol=1e-3,atol=1e-3))
+    @test all(isapprox.(to_vec(fd_vjp[1])[1], to_vec(dprogn)[1],rtol=1e-2,atol=1e-2))
 end
 
 


### PR DESCRIPTION
Based on #695 this actually runs those tests on the PR branch and not on main and also (hopefully) restricts this feature to just members of the SpeedyWeather organization 

So, now all members of the SpeedyWeather org can launch the extended tests on a PR by commenting 

/extented-tests

under a PR. The job can viewed in the Actions tab of the repo. 

Also lowers some test tolerances. 