### PR TITLE
Introduce `nothing` as valid model component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Introduce `nothing` as valid model component [#822](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/822)
 - Rename evaporation to surface humidity fluxes [#818](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/818)
 - Show architecture as "CPU"/"GPU" [#809](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/809)
 - Make dynamic Land/Ocean/SeaIce models the default [#816](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/816)

--- a/docs/src/custom_ocean.md
+++ b/docs/src/custom_ocean.md
@@ -45,18 +45,16 @@ function initialize!(
     # you can use other fields from model, e.g. model.geometry
 end
 
-function initialize!(   
+function initialize!(
     ocean::PrognosticVariablesOcean,
-    time::DateTime,
+    progn::PrognosticVariables,
+    diagn::DiagnosticVariables,
     ocean_model::CustomOceanModel,
-    model::PrimitiveEquation)
-    
+    model::PrimitiveEquation,
+)
     # your code here to initialize the prognostic variables for the ocean
     # namely, ocean.sea_surface_temperature, ocean.sea_ice_concentration, e.g.
     # ocean.sea_surface_temperature .= 300      # 300K everywhere
-
-    # ocean also has its own time, set initial time
-    ocean.time = time
 end
 ```
 
@@ -68,17 +66,15 @@ variables in the second `initialize!`. They are internally therefore also
 called in that order. Note that the function signatures should not be changed
 except to define a new method for `CustomOceanModel` or whichever name you chose.
 
-Then you have to extend the `ocean_timestep!` function which has a signature like
+Then you have to extend the `timestep!` function which has a signature like
 ```julia
-function ocean_timestep!(
-    ocean::PrognosticVariablesOcean,
-    time::DateTime,
+function timestep!(
+    progn::PrognosticVariables,
+    diagn::DiagnosticVariables,
     ocean_model::CustomOceanModel,
+    model::PrimitiveEquation,
 )
-    # your code here to change the ocean.sea_surface_temperature and/or
-    # ocean.sea_ice_concentration on any timestep
-    # you should also synchronize the clocks when executed like
-    # ocean.time = time
+    # your code here to change the progn.ocean.sea_surface_temperature
 end
 ```
 which is called on every time step before the land and before the parameterization

--- a/docs/src/examples_2D.md
+++ b/docs/src/examples_2D.md
@@ -14,8 +14,8 @@ See also [Examples 3D](@ref) for examples with the primitive equation models.
     spectral_grid = SpectralGrid(trunc=63, nlayers=1)
     still_earth = Earth(spectral_grid, rotation=0)
     initial_conditions = RandomVelocity()
-    forcing = NoForcing()
-    drag = NoDrag()
+    forcing = nothing
+    drag = nothing
     model = BarotropicModel(spectral_grid; initial_conditions, planet=still_earth, forcing, drag)
     simulation = initialize!(model)
     run!(simulation, period=Day(20))
@@ -48,8 +48,8 @@ wavenumbers are truncated.
 For free-decaying turbulence we switch off any forcing or drag with
 
 ```@example barotropic_setup
-forcing = NoForcing()
-drag = NoDrag()
+forcing = nothing
+drag = nothing
 ```
 
 Now we want to construct a `BarotropicModel` with these simply by passing
@@ -218,7 +218,7 @@ literally made up of unicode characters so the most you can expect is somthing l
 
 However, here in the documentation they are usually vertically spaced as the line
 spacing is by default higher than in the REPL.
-A similar issue arises in Jupyter Notebooks by default. Well, they are unicode
+A similar issue arises in Jupyter notebooks by default. Well, they are unicode
 after all!
 
 ### Adding mountains

--- a/docs/src/examples_3D.md
+++ b/docs/src/examples_3D.md
@@ -62,14 +62,14 @@ model = PrimitiveDryModel(
     boundary_layer_drag = LinearDrag(spectral_grid),
 
     # switch off other physics
-    convection = NoConvection(),
-    shortwave_radiation = NoShortwave(),
-    longwave_radiation = NoLongwave(),
-    vertical_diffusion = NoVerticalDiffusion(),
+    convection = nothing,
+    shortwave_radiation = nothing,
+    longwave_radiation = nothing,
+    vertical_diffusion = nothing,
 
     # switch off surface fluxes (makes ocean/land/land-sea mask redundant)
-    surface_wind = NoSurfaceWind(),
-    surface_heat_flux = NoSurfaceHeatFlux(),
+    surface_wind = nothing,
+    surface_heat_flux = nothing,
 
     # use Earth's orography
     orography = EarthOrography(spectral_grid)
@@ -85,12 +85,12 @@ and a linear drag term that is applied near the planetary boundary but switches 
 all other physics in the primitive equation model without humidity.
 Switching off the surface wind would also automatically turn off the surface evaporation
 (not relevant in the primitive _dry_ model) and sensible heat flux as that one is proportional
-to the surface wind (which is zero with `NoSurfaceWind`).
-But to also avoid the calculation being run at all we use `NoSurfaceHeatFlux()`
-for the model constructor.
-Many of the `NoSomething` model components do not require the
-spectral grid to be passed on, but as a convention we allow every model component
-to have it for construction even if not required.
+to the surface wind (which is zero with `nothing`).
+But to also avoid the calculation being run at all we use `nothing` for model components
+passed to the model constructor.
+Some model components use a `NoSomething` but most can just be set to `nothing`.
+`NoSomething`s do not require the spectral grid to be passed on, but as a convention
+we allow every model component to have it for construction even if not required.
 
 Visualising surface temperature with
 
@@ -183,12 +183,11 @@ nothing # hide
 ```
 
 But we also want to compare this to a setup where convection is completely
-disabled, i.e. `convection = NoConvection()` (many of the `No` model components
-don't require the `spectral_grid` to be passed on, but some do!)
+disabled, i.e. `convection = nothing`
 
 ```@example aquaplanet
 # Execute the code from Aquaplanet above first!
-convection = NoConvection(spectral_grid)
+convection = nothing
 
 # reuse other model components from before
 model = PrimitiveWetModel(spectral_grid; ocean, land_sea_mask, orography, convection)

--- a/docs/src/parameterizations.md
+++ b/docs/src/parameterizations.md
@@ -155,7 +155,7 @@ in the [Surface fluxes](@ref).
 ## Custom temperature relaxation
 
 By default, there is no temperature relaxation in the primitive equation
-models (i.e. `temperature_relaxation = NoTemperatureRelaxation()`).
+models (i.e. `temperature_relaxation = nothing`).
 This parameterization exists for the [Held-Suarez forcing](@ref).
 
 - subtype `CustomTemperatureRelaxation <: AbstractTemperatureRelaxation`
@@ -247,7 +247,7 @@ are called one after another
 - expected to accumulate (`+=`) into `column.flux_humid_upward`
 
 You can customize individual components and leave the other ones as default
-or by setting them to `NoSurfaceWind`, `NoSurfaceHeatFlux`, `NoSurfaceHumidityFlux`,
+or by setting them to `nothing`
 but note that without the surface wind the heat and humidity fluxes
 are also effectively disabled as they scale with the `column.surface_wind_speed`
 set by default with the `surface_wind_stress!` in (2.) above.

--- a/docs/src/sea_ice.md
+++ b/docs/src/sea_ice.md
@@ -10,28 +10,23 @@ subtypes(SpeedyWeather.AbstractSeaIce)
 
 ## No sea ice
 
-`NoSeaIce` as the name says, initializes `prognostic_variables.sea_ice_concentration` 
-to zero. But you may use `set!(simulation, sea_ice_concentration=...)` to set the
-sea ice concentration manually. `NoSeaIce` does not do anything on every time step
+You can set `sea_ice = nothing` which will not touch the initial
+`prognostic_variables.sea_ice_concentration` (which when allocated is zero),
+nor advance it. But you may use `set!(simulation, sea_ice_concentration=...)` to set the
+sea ice concentration manually. No sea ice does not do anything on every time step
 so your manual modifications will prevail after `initialize!`.
 
 To be used like
 
 ```@example sea_ice
 spectral_grid = SpectralGrid(trunc=31)
-sea_ice = NoSeaIce(spectral_grid)
-```
-
-which is then passed on to the model constructor like
-
-```@example sea_ice
-model = PrimitiveWetModel(spectral_grid; sea_ice)
+model = PrimitiveWetModel(spectral_grid; sea_ice=nothing)
 model.sea_ice
 ```
 
 Note that in SpeedyWeather the sea ice model and its albedo are defined
 independently, means you can have a sea ice model without affecting the albedo
-and `NoSeaIce` but set the sea ice concentration manually and use its albedo
+and `sea_ice=nothing` but set the sea ice concentration manually and use its albedo
 effect, this will be discussed in `ThermodynamicSeaIce` below.
 
 ## Thermodynamic sea ice model

--- a/docs/src/structure.md
+++ b/docs/src/structure.md
@@ -70,10 +70,8 @@ tree(simulation.diagnostic_variables)
 
 The `BarotropicModel` is the simplest model we have, which will not have many of
 the model components that are needed to define the primitive equations for example.
-Note that forcing or drag aren't further branched which is because the default
-`BarotropicModel` has `NoForcing` and `NoDrag` which don't have any fields. 
 If you create a model with non-default conponents they will show up here. 
-`tree` dynamicallt inspects the current contents of a (mutable) struct and
+`tree` dynamically inspects the current contents of a (mutable) struct and
 that tree may look different depending on what model you have constructed!
 
 ```@example structure

--- a/docs/src/surface_fluxes.md
+++ b/docs/src/surface_fluxes.md
@@ -23,7 +23,7 @@ subtypes(SpeedyWeather.AbstractSurfaceWind)
 
 !!! note "Interdependence of surface flux computations"
     `SurfaceWind` computes the surface fluxes of momentum but also the computation
-    of the surface wind (which by default includes wind gusts) meaning that `NoSurfaceWind`
+    of the surface wind (which by default includes wind gusts) meaning that `surface_wind_speed=nothing`
     will also effectively disable other surface fluxes unless custom surface fluxes
     have been implemented that do not rely on `column.surface_wind_speed`.
 

--- a/docs/src/vertical_diffusion.md
+++ b/docs/src/vertical_diffusion.md
@@ -19,7 +19,7 @@ using SpeedyWeather
 subtypes(SpeedyWeather.AbstractVerticalDiffusion)
 ```
 
-`NoVerticalDiffusion` disabled all vertical diffusion,
+You can always set `vertical_diffusion=nothing` which will disable all vertical diffusion.
 `BulkRichardsonDiffusion` is explained in the following.
 
 ## Laplacian in sigma coordinates

--- a/src/SpeedyWeather.jl
+++ b/src/SpeedyWeather.jl
@@ -111,7 +111,6 @@ function animate end
 # abstract types
 include("models/abstract_models.jl")
 include("dynamics/abstract_types.jl")
-include("physics/abstract_types.jl")
 
 # GEOMETRY CONSTANTS ETC
 include("dynamics/vertical_coordinates.jl")

--- a/src/Utils/kernel_launching.jl
+++ b/src/Utils/kernel_launching.jl
@@ -1,6 +1,7 @@
 import ..device
 
-# Support for 1D, To-DO: do we need higher dim workgroups like Oceananigans? Not in one horizontal level (because LTA/Rings), but maybe when we include vertical?
+# Support for 1D, To-DO: do we need higher dim workgroups like Oceananigans?
+# Not in one horizontal level (because LTA/Rings), but maybe when we include vertical?
 heuristic_workgroup(Wx) = min(Wx, 256)
 
 # horizontal + vertical, 3D 

--- a/src/dynamics/drag.jl
+++ b/src/dynamics/drag.jl
@@ -11,17 +11,7 @@ function drag!(
 end
 
 ## NO DRAG
-export NoDrag
-struct NoDrag <: AbstractDrag end
-NoDrag(SG::SpectralGrid) = NoDrag()
-initialize!(::NoDrag, ::AbstractModel) = nothing
-
-function drag!(     diagn::DiagnosticVariables,
-                    progn::PrognosticVariables,
-                    drag::NoDrag,
-                    args...)
-    return nothing
-end
+drag!(diagn, progn, drag::Nothing, args...) = nothing
 
 # Quadratic drag
 export QuadraticDrag
@@ -31,8 +21,6 @@ export QuadraticDrag
 end
 
 QuadraticDrag(SG::SpectralGrid; kwargs...) = QuadraticDrag{SG.NF}(; kwargs...)
-
-initialize!(::QuadraticDrag, ::AbstractModel) = nothing
 
 """
 $(TYPEDSIGNATURES)
@@ -75,8 +63,6 @@ export LinearVorticityDrag
 end
 
 LinearVorticityDrag(SG::SpectralGrid; kwargs...) = LinearVorticityDrag{SG.NF}(; kwargs...)
-
-initialize!(::LinearVorticityDrag, ::AbstractModel) = nothing
 
 """
 $(TYPEDSIGNATURES)

--- a/src/dynamics/forcing.jl
+++ b/src/dynamics/forcing.jl
@@ -10,20 +10,8 @@ function forcing!(
     forcing!(diagn, progn, model.forcing, lf, model)
 end
 
-## NO FORCING = dummy forcing
-export NoForcing
-struct NoForcing <: AbstractForcing end
-NoForcing(SG::SpectralGrid) = NoForcing()
-initialize!(::NoForcing, ::AbstractModel) = nothing
-
-function forcing!(  
-    diagn::DiagnosticVariables,
-    progn::PrognosticVariables,
-    forcing::NoForcing,
-    args...,
-)
-    return nothing
-end
+## NO FORCING
+forcing!(diagn, progn, forcing::Nothing, args...) = nothing
 
 # JET STREAM FORCING
 export JetStreamForcing
@@ -165,8 +153,8 @@ function initialize!(
     forcing::StochasticStirring,
     model::AbstractModel)
     
-    model.random_process isa NoRandomProcess &&
-        @warn "StochasticStirring needs a random process. model.random_process is a NoRandomProcess."
+    model.random_process isa Nothing &&
+        @warn "StochasticStirring needs a random process. model.random_process is nothing."
 
     # precompute the latitudinal mask
     (; latd) = model.geometry
@@ -226,8 +214,6 @@ $(TYPEDFIELDS)
 end
 
 KolmogorovFlow(SG::SpectralGrid; kwargs...) = KolmogorovFlow{SG.NF}(; kwargs...)
-
-initialize!(::KolmogorovFlow, ::AbstractModel) = nothing
 
 function forcing!(
     diagn::DiagnosticVariables,

--- a/src/dynamics/hole_filling.jl
+++ b/src/dynamics/hole_filling.jl
@@ -1,25 +1,21 @@
-abstract type AbstractHoleFilling end
+abstract type AbstractHoleFilling <: AbstractModelComponent end
 
-export NoHoleFilling
-struct NoHoleFilling <: AbstractHoleFilling end
-NoHoleFilling(SG::SpectralGrid) = NoHoleFilling()
-initialize!(::NoHoleFilling, ::PrimitiveWet) = nothing
-hole_filling!(::AbstractGrid,::NoHoleFilling,::PrimitiveWet) = nothing
+# no hole filling
+hole_filling!(::AbstractField, ::Nothing, ::AbstractModel) = nothing
 
 export ClipNegatives
 struct ClipNegatives <: AbstractHoleFilling end
 ClipNegatives(SG::SpectralGrid) = ClipNegatives()
-initialize!(::ClipNegatives, ::PrimitiveWet) = nothing
 
 # function barrier
 function hole_filling!(
     q::AbstractField,
     H::ClipNegatives,
-    model::PrimitiveWet
+    model::AbstractModel,
 )
     hole_filling!(q, H)
 end
 
-function hole_filling!(q::AbstractField,::ClipNegatives)
+function hole_filling!(q::AbstractField, ::ClipNegatives)
     @. q = max(q, 0)
 end

--- a/src/dynamics/implicit.jl
+++ b/src/dynamics/implicit.jl
@@ -1,7 +1,8 @@
 abstract type AbstractImplicit <: AbstractModelComponent end
 
-# BAROTROPIC MODEL (no implicit needed)
-implicit_correction!(diagn, progn, ::Nothing) = nothing
+# model.implicit=nothing (for BarotropicModel)
+initialize!(::Nothing, dt::Real, ::DiagnosticVariables, ::AbstractModel) = nothing
+implicit_correction!(::DiagnosticVariables, ::PrognosticVariables, ::Nothing) = nothing
 
 # SHALLOW WATER MODEL
 export ImplicitShallowWater

--- a/src/dynamics/implicit.jl
+++ b/src/dynamics/implicit.jl
@@ -1,11 +1,7 @@
 abstract type AbstractImplicit <: AbstractModelComponent end
 
 # BAROTROPIC MODEL (no implicit needed)
-export NoImplicit
-struct NoImplicit <: AbstractImplicit end
-NoImplicit(SG::SpectralGrid) = NoImplicit()
-initialize!(::NoImplicit, args...) = nothing
-implicit_correction!(::DiagnosticVariables, ::PrognosticVariables, ::NoImplicit) = nothing
+implicit_correction!(diagn, progn, ::Nothing) = nothing
 
 # SHALLOW WATER MODEL
 export ImplicitShallowWater

--- a/src/dynamics/particle_advection.jl
+++ b/src/dynamics/particle_advection.jl
@@ -1,15 +1,11 @@
 abstract type AbstractParticleAdvection <: AbstractModelComponent end
 
-# dummy no particle advection type
-export NoParticleAdvection
-struct NoParticleAdvection <: AbstractParticleAdvection end
-NoParticleAdvection(::SpectralGrid) = NoParticleAdvection()
-initialize!(::NoParticleAdvection, ::AbstractModel) = nothing
-initialize!(particles, progn, diagn, ::NoParticleAdvection) = nothing
-particle_advection!(progn, diagn, ::NoParticleAdvection) = nothing
+# no particle advection
+initialize!(particles, progn, diagn, ::Nothing) = nothing
+particle_advection!(progn, diagn, ::Nothing) = nothing
 
 export ParticleAdvection2D
-Base.@kwdef struct ParticleAdvection2D{NF} <: AbstractParticleAdvection
+@kwdef struct ParticleAdvection2D{NF} <: AbstractParticleAdvection
     "[OPTION] Execute particle advection every n timesteps"
     every_n_timesteps::Int = 6
 

--- a/src/dynamics/particles.jl
+++ b/src/dynamics/particles.jl
@@ -87,7 +87,7 @@ function Base.show(io::IO,p::Particle{NF}) where {NF}
     lat = @sprintf("%6.2f",p.lat)
     lon = @sprintf("%6.2f",p.lon)
     σ = @sprintf("%.2f",p.σ)
-    print(io,"Particle{$NF}($(lon)˚E, $(lat)˚N, σ = $σ, $(p.active) ? active : inactive)")
+    print(io,"Particle{$NF}($(p.active ? "  active" : "inactive"), $(lon)˚E, $(lat)˚N, σ = $σ)")
 end
 
 export move

--- a/src/dynamics/random_process.jl
+++ b/src/dynamics/random_process.jl
@@ -20,26 +20,20 @@ function SpeedyTransforms.transform!(
     end
 end
 
-export NoRandomProcess
-"""Dummy type for no random process."""
-struct NoRandomProcess <: AbstractRandomProcess end
-NoRandomProcess(::SpectralGrid) = NoRandomProcess()
-
 """$(TYPEDSIGNATURES)
-`NoRandomProcess` does not need to transform any random pattern from
+`random_process=nothing` does not need to transform any random pattern from
 spectral to grid space."""
 function SpeedyTransforms.transform!(
     diagn::DiagnosticVariables,
     progn::PrognosticVariables,
     lf::Integer,
-    random_process::NoRandomProcess,
+    random_process::Nothing,
     spectral_transform::SpectralTransform,
 )
     return nothing
 end
 
-initialize!(process::NoRandomProcess, model::AbstractModel) = nothing
-random_process!(progn::PrognosticVariables, process::NoRandomProcess) = nothing
+random_process!(progn::PrognosticVariables, process::Nothing) = nothing
 
 export SpectralAR1Process
 

--- a/src/dynamics/spectral_grid.jl
+++ b/src/dynamics/spectral_grid.jl
@@ -228,3 +228,7 @@ function SpeedyTransforms.SpectralTransform(spectral_grid::SpectralGrid;
     spectrum = one_more_degree == false ? Spectrum(lmax-1, mmax; architecture) : spectrum
     return SpectralTransform(spectrum, grid; NF, ArrayType, nlayers, kwargs...)
 end
+
+# because model components can be `nothing`, their constructor being `Nothing()`
+# we also allow `::SpectralGrid` as the first argument
+Base.Nothing(::SpectralGrid) = Nothing()

--- a/src/dynamics/tendencies.jl
+++ b/src/dynamics/tendencies.jl
@@ -797,7 +797,7 @@ function SpeedyTransforms.transform!(
         tracer.active && transform!(diagn.grid.tracers_grid[name], tracer_var, scratch_memory, S)
     end
 
-    # transform random pattern for random process unless NoRandomProcess
+    # transform random pattern for random process unless random_process=nothing
     transform!(diagn, progn, lf, model.random_process, S)
 
     return nothing
@@ -846,7 +846,7 @@ function SpeedyTransforms.transform!(
         tracer.active && transform!(diagn.grid.tracers_grid[name], tracer_var, scratch_memory, S)
     end
 
-    # transform random pattern for random process unless NoRandomProcess
+    # transform random pattern for random process unless random_process=nothing
     transform!(diagn, progn, lf, model.random_process, S)
 
     return nothing
@@ -945,7 +945,7 @@ function SpeedyTransforms.transform!(
         tracer.active && transform!(diagn.grid.tracers_grid[name], tracer_var, scratch_memory, S)
     end
 
-    # transform random pattern for random process unless NoRandomProcess
+    # transform random pattern for random process unless random_process=nothing
     transform!(diagn, progn, lf, model.random_process, S)
 
     return nothing

--- a/src/dynamics/time_integration.jl
+++ b/src/dynamics/time_integration.jl
@@ -291,7 +291,7 @@ function timestep!(
 
     # PARTICLE ADVECTION (always skip 1st step of first_timesteps!)
     not_first_timestep = lf2 == 2
-    not_first_timestep && particle_advection!(progn, diagn, model.particle_advection)
+    not_first_timestep && particle_advection!(progn, diagn, model)
 
     return nothing 
 end
@@ -323,7 +323,7 @@ function timestep!(
     
     # PARTICLE ADVECTION (always skip 1st step of first_timesteps!)
     not_first_timestep = lf2 == 2
-    not_first_timestep && particle_advection!(progn, diagn, model.particle_advection)
+    not_first_timestep && particle_advection!(progn, diagn, model)
 
     return nothing
 end
@@ -370,7 +370,7 @@ function timestep!(
 
     # PARTICLE ADVECTION (always skip 1st step of first_timesteps!)
     not_first_timestep = lf2 == 2
-    not_first_timestep && particle_advection!(progn, diagn, model.particle_advection)
+    not_first_timestep && particle_advection!(progn, diagn, model)
 
     return nothing 
 end

--- a/src/models/abstract_models.jl
+++ b/src/models/abstract_models.jl
@@ -10,6 +10,14 @@ abstract type PrimitiveWet <: PrimitiveEquation end
 
 abstract type AbstractModelComponent end
 
+# any model component set to nothing needs no initialization or finalize!
+initialize!(::Nothing, ::AbstractModel) = nothing
+finalize!(::Nothing, ::AbstractModel) = nothing
+
+# fallback for model components: nothing to initialize
+initialize!(::AbstractModelComponent, ::AbstractModel) = nothing
+finalize!(::AbstractModelComponent, ::AbstractModel) = nothing
+
 # print all fields with type <: Number
 function Base.show(io::IO, P::AbstractModelComponent)
     println(io, "$(typeof(P)) <: $(supertype(typeof(P)))")

--- a/src/models/abstract_models.jl
+++ b/src/models/abstract_models.jl
@@ -9,9 +9,16 @@ abstract type PrimitiveDry <: PrimitiveEquation end
 abstract type PrimitiveWet <: PrimitiveEquation end
 
 abstract type AbstractModelComponent end
+abstract type AbstractParameterization <: AbstractModelComponent end
 
 # any model component set to nothing needs no initialization or finalize!
 initialize!(::Nothing, ::AbstractModel) = nothing
+
+# allow for components that initialize variables to be nothing
+initialize!(p, d, ::Nothing, ::AbstractModel) = nothing
+# or sub parts of the prognostic variables; this makes land=nothing, ocean=nothing possible
+initialize!(psub, p, d, ::Nothing, ::AbstractModel) = nothing
+timestep!(p, d, ::Nothing, ::AbstractModel) = nothing
 finalize!(::Nothing, ::AbstractModel) = nothing
 
 # fallback for model components: nothing to initialize

--- a/src/models/barotropic.jl
+++ b/src/models/barotropic.jl
@@ -39,17 +39,17 @@ $(TYPEDFIELDS)"""
     coriolis::CO = Coriolis(spectral_grid)
     forcing::FR = KolmogorovFlow(spectral_grid)
     drag::DR = LinearVorticityDrag(spectral_grid)
-    particle_advection::PA = NoParticleAdvection()
+    particle_advection::PA = nothing
     initial_conditions::IC = InitialConditions(Barotropic)
     
     # VARIABLES
-    random_process::RP = NoRandomProcess(spectral_grid)
+    random_process::RP = nothing
     tracers::TRACER_DICT = TRACER_DICT()
 
     # NUMERICS
     time_stepping::TS = Leapfrog(spectral_grid)
     spectral_transform::ST = SpectralTransform(spectral_grid)
-    implicit::IM = NoImplicit(spectral_grid)
+    implicit::IM = nothing
     horizontal_diffusion::HD = HyperDiffusion(spectral_grid)
 
     # OUTPUT

--- a/src/models/barotropic.jl
+++ b/src/models/barotropic.jl
@@ -86,17 +86,20 @@ function initialize!(model::Barotropic; time::DateTime = DEFAULT_DATE)
     initialize!(model.drag, model)
     initialize!(model.horizontal_diffusion, model)
     initialize!(model.random_process, model)
-
-    # initial conditions
-    prognostic_variables = PrognosticVariables(spectral_grid, model)
-    initialize!(prognostic_variables, model.initial_conditions, model)
-    prognostic_variables.clock.time = time       # set the current time
-    prognostic_variables.clock.start = time      # and store the start time
-
-    # particle advection
     initialize!(model.particle_advection, model)
-    initialize!(prognostic_variables.particles, model)
 
+    # allocate prognostic and diagnostic variables
+    prognostic_variables = PrognosticVariables(spectral_grid, model)
     diagnostic_variables = DiagnosticVariables(spectral_grid, model)
+    
+    # initialize particles (or other non-atmosphere prognostic variables)
+    initialize!(prognostic_variables.particles, prognostic_variables, diagnostic_variables, model)
+    
+    # set the initial conditions 
+    initialize!(prognostic_variables, model.initial_conditions, model)
+    (; clock) = prognostic_variables
+    clock.time = time       # set the current time
+    clock.start = time      # and store the start time
+
     return Simulation(prognostic_variables, diagnostic_variables, model)
 end

--- a/src/models/primitive_dry.jl
+++ b/src/models/primitive_dry.jl
@@ -150,18 +150,17 @@ function initialize!(model::PrimitiveDry; time::DateTime = DEFAULT_DATE)
     initialize!(model.surface_wind, model)
     initialize!(model.surface_heat_flux, model)
     initialize!(model.stochastic_physics, model)
+    initialize!(model.particle_advection, model)
 
     # allocate prognostic and diagnostic variables
     prognostic_variables = PrognosticVariables(spectral_grid, model)
     diagnostic_variables = DiagnosticVariables(spectral_grid, model)
     
-    # particle advection
-    initialize!(model.particle_advection, model)
-    initialize!(prognostic_variables.particles, model)
-    
-    # initialize ocean (includes sea ice) and land
-    initialize!(prognostic_variables.ocean, prognostic_variables, diagnostic_variables, model)
-    initialize!(prognostic_variables.land,  prognostic_variables, diagnostic_variables, model)
+    # initialize non-atmosphere prognostic variables
+    (; particles, ocean, land) = prognostic_variables
+    initialize!(particles, prognostic_variables, diagnostic_variables, model)
+    initialize!(ocean,     prognostic_variables, diagnostic_variables, model)
+    initialize!(land,      prognostic_variables, diagnostic_variables, model)
 
     # set the initial conditions (may overwrite variables set in intialize! ocean/land)
     initialize!(prognostic_variables, model.initial_conditions, model)

--- a/src/models/primitive_dry.jl
+++ b/src/models/primitive_dry.jl
@@ -61,13 +61,13 @@ $(TYPEDFIELDS)"""
     coriolis::CO = Coriolis(spectral_grid)
     geopotential::GO = Geopotential(spectral_grid)
     adiabatic_conversion::AC = AdiabaticConversion(spectral_grid)
-    particle_advection::PA = NoParticleAdvection()
+    particle_advection::PA = nothing
     initial_conditions::IC = InitialConditions(PrimitiveDry)
-    forcing::FR = NoForcing()
-    drag::DR = NoDrag()
-  
+    forcing::FR = nothing
+    drag::DR = nothing
+
     # VARIABLES
-    random_process::RP = NoRandomProcess()
+    random_process::RP = nothing
     tracers::TRACER_DICT = TRACER_DICT()
 
     # BOUNDARY CONDITIONS
@@ -82,7 +82,7 @@ $(TYPEDFIELDS)"""
     # PHYSICS/PARAMETERIZATIONS
     physics::Bool = true
     boundary_layer_drag::BL = BulkRichardsonDrag(spectral_grid)
-    temperature_relaxation::TR = NoTemperatureRelaxation(spectral_grid)
+    temperature_relaxation::TR = nothing
     vertical_diffusion::VD = BulkRichardsonDiffusion(spectral_grid)
     surface_thermodynamics::SUT = SurfaceThermodynamicsConstant(spectral_grid)
     surface_wind::SUW = SurfaceWind(spectral_grid)
@@ -91,7 +91,7 @@ $(TYPEDFIELDS)"""
     optical_depth::OD = ZeroOpticalDepth(spectral_grid)
     shortwave_radiation::SW = TransparentShortwave(spectral_grid)
     longwave_radiation::LW = JeevanjeeRadiation(spectral_grid)
-    stochastic_physics::SP = NoStochasticPhysics()
+    stochastic_physics::SP = nothing
     
     # NUMERICS
     time_stepping::TS = Leapfrog(spectral_grid)

--- a/src/models/primitive_wet.jl
+++ b/src/models/primitive_wet.jl
@@ -160,18 +160,17 @@ function initialize!(model::PrimitiveWet; time::DateTime = DEFAULT_DATE)
     initialize!(model.surface_heat_flux, model)
     initialize!(model.surface_humidity_flux, model)
     initialize!(model.stochastic_physics, model)
+    initialize!(model.particle_advection, model)
 
     # allocate prognostic and diagnostic variables
     prognostic_variables = PrognosticVariables(spectral_grid, model)
     diagnostic_variables = DiagnosticVariables(spectral_grid, model)
-    
-    # particle advection
-    initialize!(model.particle_advection, model)
-    initialize!(prognostic_variables.particles, model)
-    
-    # initialize ocean (includes sea ice) and land
-    initialize!(prognostic_variables.ocean, prognostic_variables, diagnostic_variables, model)
-    initialize!(prognostic_variables.land,  prognostic_variables, diagnostic_variables, model)
+
+    # initialize non-atmosphere prognostic variables
+    (; particles, ocean, land) = prognostic_variables
+    initialize!(particles, prognostic_variables, diagnostic_variables, model)
+    initialize!(ocean,     prognostic_variables, diagnostic_variables, model)
+    initialize!(land,      prognostic_variables, diagnostic_variables, model)
 
     # set the initial conditions (may overwrite variables set in intialize! ocean/land)
     initialize!(prognostic_variables, model.initial_conditions, model)

--- a/src/models/primitive_wet.jl
+++ b/src/models/primitive_wet.jl
@@ -65,13 +65,13 @@ $(TYPEDFIELDS)"""
     coriolis::CO = Coriolis(spectral_grid)
     geopotential::GO = Geopotential(spectral_grid)
     adiabatic_conversion::AC = AdiabaticConversion(spectral_grid)
-    particle_advection::PA = NoParticleAdvection()
+    particle_advection::PA = nothing
     initial_conditions::IC = InitialConditions(PrimitiveWet)
-    forcing::FR = NoForcing()
-    drag::DR = NoDrag()  
-  
+    forcing::FR = nothing
+    drag::DR = nothing
+
     # VARIABLES
-    random_process::RP = NoRandomProcess()
+    random_process::RP = nothing
     tracers::TRACER_DICT = TRACER_DICT()
     
     # BOUNDARY CONDITIONS
@@ -87,7 +87,7 @@ $(TYPEDFIELDS)"""
     physics::Bool = true
     clausius_clapeyron::CC = ClausiusClapeyron(spectral_grid, atmosphere)
     boundary_layer_drag::BL = BulkRichardsonDrag(spectral_grid)
-    temperature_relaxation::TR = NoTemperatureRelaxation(spectral_grid)
+    temperature_relaxation::TR = nothing
     vertical_diffusion::VD = BulkRichardsonDiffusion(spectral_grid)
     surface_thermodynamics::SUT = SurfaceThermodynamicsConstant(spectral_grid)
     surface_wind::SUW = SurfaceWind(spectral_grid)
@@ -98,8 +98,8 @@ $(TYPEDFIELDS)"""
     optical_depth::OD = ZeroOpticalDepth(spectral_grid)
     shortwave_radiation::SW = TransparentShortwave(spectral_grid)
     longwave_radiation::LW = JeevanjeeRadiation(spectral_grid)
-    stochastic_physics::SP = NoStochasticPhysics()
-    
+    stochastic_physics::SP = nothing
+
     # NUMERICS
     time_stepping::TS = Leapfrog(spectral_grid)
     spectral_transform::ST = SpectralTransform(spectral_grid)

--- a/src/models/shallow_water.jl
+++ b/src/models/shallow_water.jl
@@ -83,17 +83,19 @@ function initialize!(model::ShallowWater; time::DateTime = DEFAULT_DATE)
     initialize!(model.horizontal_diffusion, model)
     # model.implicit is initialized in first_timesteps!
     initialize!(model.random_process, model)
-
-    # initial conditions
-    prognostic_variables = PrognosticVariables(spectral_grid, model)
-    initialize!(prognostic_variables, model.initial_conditions, model)
-    prognostic_variables.clock.time = time       # set the current time
-    prognostic_variables.clock.start = time      # and store the start time
-
-    # particle advection
     initialize!(model.particle_advection, model)
-    initialize!(prognostic_variables.particles, model)
 
+    # allocate variables
+    prognostic_variables = PrognosticVariables(spectral_grid, model)
     diagnostic_variables = DiagnosticVariables(spectral_grid, model)
+
+    # initialize non-atmosphere prognostic variables
+    initialize!(prognostic_variables.particles, prognostic_variables, diagnostic_variables, model)
+
+    initialize!(prognostic_variables, model.initial_conditions, model)
+    (; clock) = prognostic_variables
+    clock.time = time       # set the current time
+    clock.start = time      # and store the start time
+
     return Simulation(prognostic_variables, diagnostic_variables, model)
 end

--- a/src/models/shallow_water.jl
+++ b/src/models/shallow_water.jl
@@ -39,13 +39,13 @@ $(TYPEDFIELDS)"""
     atmosphere::AT = EarthAtmosphere(spectral_grid)
     coriolis::CO = Coriolis(spectral_grid)
     orography::OR = EarthOrography(spectral_grid)
-    forcing::FR = NoForcing()
-    drag::DR = NoDrag()
-    particle_advection::PA = NoParticleAdvection()
+    forcing::FR = nothing
+    drag::DR = nothing
+    particle_advection::PA = nothing
     initial_conditions::IC = InitialConditions(ShallowWater)
     
     # VARIABLES
-    random_process::RP = NoRandomProcess()
+    random_process::RP = nothing
     tracers::TRACER_DICT = TRACER_DICT()
 
     # NUMERICS

--- a/src/models/simulation.jl
+++ b/src/models/simulation.jl
@@ -83,7 +83,7 @@ function initialize!(
     # propagate spectral state to grid variables for initial condition output
     lf = 1                                  # use first leapfrog index
     transform!(diagn, progn, lf, model, initialize=true)
-    initialize!(progn.particles, progn, diagn, model.particle_advection)
+    initialize!(diagn, progn.particles, progn, model)
     initialize!(model.output, model.feedback, progn, diagn, model)
     initialize!(model.callbacks, progn, diagn, model)
 end

--- a/src/physics/abstract_types.jl
+++ b/src/physics/abstract_types.jl
@@ -1,1 +1,0 @@
-abstract type AbstractParameterization <: AbstractModelComponent end

--- a/src/physics/boundary_layer.jl
+++ b/src/physics/boundary_layer.jl
@@ -6,12 +6,8 @@ function boundary_layer_drag!(  column::ColumnVariables,
     boundary_layer_drag!(column, model.boundary_layer_drag, model)
 end
 
-# dummy boundary layer
-export NoBoundaryLayerDrag
-struct NoBoundaryLayerDrag <: AbstractBoundaryLayer end
-NoBoundaryLayerDrag(::SpectralGrid) = NoBoundaryLayerDrag()
-initialize!(::NoBoundaryLayerDrag, ::PrimitiveEquation) = nothing
-boundary_layer_drag!(::ColumnVariables, ::NoBoundaryLayerDrag, ::PrimitiveEquation) = nothing
+# no boundary layer drag
+boundary_layer_drag!(::ColumnVariables, ::Nothing, ::PrimitiveEquation) = nothing
 
 export LinearDrag
 

--- a/src/physics/convection.jl
+++ b/src/physics/convection.jl
@@ -1,8 +1,5 @@
 abstract type AbstractSurfacePerturbation <: AbstractParameterization end
 
-# subtypes don't require an initialize! method defined by default
-initialize!(::AbstractSurfacePerturbation, ::PrimitiveEquation) = nothing
-
 export NoSurfacePerturbation
 
 """Returns the surface temperature and humidity without
@@ -31,13 +28,8 @@ end
 
 abstract type AbstractConvection <: AbstractParameterization end
 
-export NoConvection
-
-"""Dummy type to disable convection."""
-struct NoConvection <: AbstractConvection end
-NoConvection(::SpectralGrid) = NoConvection()
-initialize!(::NoConvection, ::PrimitiveEquation) = nothing
-convection!(::ColumnVariables, ::NoConvection, ::PrimitiveEquation) = nothing
+# no convection
+convection!(::ColumnVariables, ::Nothing, ::PrimitiveEquation) = nothing
 
 export SimplifiedBettsMiller
 

--- a/src/physics/land/land.jl
+++ b/src/physics/land/land.jl
@@ -40,7 +40,7 @@ export LandModel
     temperature::T = LandBucketTemperature(spectral_grid)
     soil_moisture::SM = LandBucketMoisture(spectral_grid)
     vegetation::V = VegetationClimatology(spectral_grid)
-    rivers::R = NoRivers(spectral_grid)
+    rivers::R = nothing
 end
 
 # also allow spectral grid to be passed on as first an only positional argument to model constructors

--- a/src/physics/land/land.jl
+++ b/src/physics/land/land.jl
@@ -71,10 +71,11 @@ function initialize!(land::DryLandModel, model::PrimitiveEquation)
     initialize!(model.land.temperature, model)
 end
 
+# unpack land model and call general timestep! function
 land_timestep!(progn::PrognosticVariables, diagn::DiagnosticVariables, model::PrimitiveEquation) =
-    land_timestep!(progn, diagn, model.land, model)
+    timestep!(progn, diagn, model.land, model)
 
-function land_timestep!(
+function timestep!(
     progn::PrognosticVariables,
     diagn::DiagnosticVariables,
     land::AbstractLand,
@@ -95,12 +96,23 @@ function initialize!(
     diagn::DiagnosticVariables,
     model::PrimitiveEquation,
 )
-    initialize!(progn, diagn, model.land.temperature, model)
+    # unpack model.land to dispatch over it and so that model.land = nothing is valid
+    initialize!(land, progn, diagn, model.land, model)
+end
+
+function initialize!(
+    land::PrognosticVariablesLand,  # for dispatch
+    progn::PrognosticVariables,
+    diagn::DiagnosticVariables,
+    land_model::AbstractLand,
+    model::PrimitiveEquation,
+)
+    initialize!(progn, diagn, land_model.temperature, model)
 
     # only initialize soil moisture, vegetation, rivers if atmosphere and land are wet
-    if model isa PrimitiveWet && model.land isa AbstractWetLand
-        initialize!(progn, diagn, model.land.soil_moisture, model)      
-        initialize!(progn, diagn, model.land.vegetation, model)     
-        initialize!(progn, diagn, model.land.rivers, model)
+    if model isa PrimitiveWet && land_model isa AbstractWetLand
+        initialize!(progn, diagn, land_model.soil_moisture, model)      
+        initialize!(progn, diagn, land_model.vegetation, model)     
+        initialize!(progn, diagn, land_model.rivers, model)
     end
 end

--- a/src/physics/land/rivers.jl
+++ b/src/physics/land/rivers.jl
@@ -1,8 +1,5 @@
 abstract type AbstractRivers <: AbstractParameterization end
 
-export NoRivers
-struct NoRivers <: AbstractRivers end
-NoRivers(SG::SpectralGrid) = NoRivers()
-initialize!(rivers::NoRivers, model::PrimitiveEquation) = nothing
-initialize!(::PrognosticVariables, ::DiagnosticVariables, ::NoRivers, ::PrimitiveEquation) = nothing
-timestep!(progn::PrognosticVariables, diagn::DiagnosticVariables, rivers::NoRivers, model::PrimitiveEquation) = nothing
+# no rivers
+initialize!(::PrognosticVariables, ::DiagnosticVariables, ::Nothing, ::PrimitiveEquation) = nothing
+timestep!(progn, diagn, rivers::Nothing, model) = nothing

--- a/src/physics/land/rivers.jl
+++ b/src/physics/land/rivers.jl
@@ -1,5 +1,3 @@
 abstract type AbstractRivers <: AbstractParameterization end
 
-# no rivers
-initialize!(::PrognosticVariables, ::DiagnosticVariables, ::Nothing, ::PrimitiveEquation) = nothing
-timestep!(progn, diagn, rivers::Nothing, model) = nothing
+# no rivers defined as rivers=nothing

--- a/src/physics/land/soil_moisture.jl
+++ b/src/physics/land/soil_moisture.jl
@@ -1,23 +1,5 @@
 abstract type AbstractSoilMoisture <: AbstractParameterization end
 
-function initialize!(
-    progn::PrognosticVariables,
-    diagn::DiagnosticVariables,
-    soil::Nothing,
-    model::PrimitiveEquation,
-)
-    return nothing
-end
-
-function timestep!(
-    progn::PrognosticVariables,
-    diagn::DiagnosticVariables,
-    soil::Nothing,
-    model::PrimitiveEquation,
-)
-    return nothing
-end
-
 export SeasonalSoilMoisture
 @kwdef mutable struct SeasonalSoilMoisture{NF, GridVariable4D} <: AbstractSoilMoisture
     # READ CLIMATOLOGY FROM FILE

--- a/src/physics/land/soil_moisture.jl
+++ b/src/physics/land/soil_moisture.jl
@@ -1,14 +1,9 @@
 abstract type AbstractSoilMoisture <: AbstractParameterization end
 
-export NoSoilMoisture
-struct NoSoilMoisture <: AbstractSoilMoisture end
-NoSoilMoisture(SG::SpectralGrid) = NoSoilMoisture()
-initialize!(soil::NoSoilMoisture, model::PrimitiveEquation) = nothing
-
 function initialize!(
     progn::PrognosticVariables,
     diagn::DiagnosticVariables,
-    soil::NoSoilMoisture,
+    soil::Nothing,
     model::PrimitiveEquation,
 )
     return nothing
@@ -17,7 +12,7 @@ end
 function timestep!(
     progn::PrognosticVariables,
     diagn::DiagnosticVariables,
-    soil::NoSoilMoisture,
+    soil::Nothing,
     model::PrimitiveEquation,
 )
     return nothing

--- a/src/physics/large_scale_condensation.jl
+++ b/src/physics/large_scale_condensation.jl
@@ -1,10 +1,7 @@
 abstract type AbstractCondensation <: AbstractParameterization end
 
-export NoCondensation
-struct NoCondensation <: AbstractCondensation end
-NoCondesantion(::SpectralGrid) = NoCondensation()
-initialize!(::NoCondensation, ::PrimitiveEquation) = nothing
-large_scale_condensation!(::ColumnVariables, ::NoCondensation, ::PrimitiveEquation) = nothing
+# no condensation
+large_scale_condensation!(::ColumnVariables, ::Nothing, ::PrimitiveEquation) = nothing
 
 export ImplicitCondensation
 """
@@ -36,7 +33,7 @@ function large_scale_condensation!(
     column::ColumnVariables,
     model::PrimitiveWet,
 )
-    #TODO not needed for NoCondensation
+    #TODO not needed for no condensation
     saturation_humidity!(column, model.clausius_clapeyron)
     large_scale_condensation!(column, model.large_scale_condensation, model)
 end

--- a/src/physics/longwave_radiation.jl
+++ b/src/physics/longwave_radiation.jl
@@ -1,11 +1,8 @@
 abstract type AbstractRadiation <: AbstractParameterization end
 abstract type AbstractLongwave <: AbstractRadiation end
 
-export NoLongwave
-struct NoLongwave <: AbstractLongwave end
-NoLongwave(SG::SpectralGrid) = NoLongwave()
-initialize!(::NoLongwave, ::PrimitiveEquation) = nothing
-longwave_radiation!(::ColumnVariables, ::NoLongwave, ::PrimitiveEquation) = nothing
+# no longwave radiation
+longwave_radiation!(::ColumnVariables, ::Nothing, ::PrimitiveEquation) = nothing
 
 # function barrier for all AbstractLongwave
 function longwave_radiation!(column::ColumnVariables, model::PrimitiveEquation)

--- a/src/physics/ocean.jl
+++ b/src/physics/ocean.jl
@@ -25,14 +25,13 @@ the following functions
         # ocean.sea_surface_temperature .= 300      # 300K everywhere
     end
 
-    function ocean_timestep!(
+    function timestep!(
         progn::PrognosticVariables,
         diagn::DiagnosticVariables,
         ocean_model::CustomOceanModel,
         model::PrimitiveEquation,
     )
-        # your code here to change the progn.ocean.sea_surface_temperature and/or
-        # progn.ocean.sea_ice_concentration on any timestep
+        # your code here to change the progn.ocean.sea_surface_temperature
     end
 
 Temperatures in ocean.sea_surface_temperature have units of Kelvin,
@@ -43,7 +42,7 @@ be (fractionally) ignored in the calculation of surface fluxes (potentially lead
 to a zero flux depending on land surface temperatures). For an ocean grid-cell that is NaN
 but not masked by the land-sea mask, its value is always ignored.
 """
-abstract type AbstractOcean end
+abstract type AbstractOcean <: AbstractModelComponent end
 
 function Base.show(io::IO, O::AbstractOcean)
     println(io, "$(typeof(O)) <: AbstractOcean")
@@ -64,7 +63,7 @@ end
 function ocean_timestep!(   progn::PrognosticVariables,
                             diagn::DiagnosticVariables,
                             model::PrimitiveEquation)
-    ocean_timestep!(progn, diagn, model.ocean, model)
+    timestep!(progn, diagn, model.ocean, model)
 end
 
 
@@ -143,10 +142,10 @@ function initialize!(
     ocean_model::SeasonalOceanClimatology,
     model::PrimitiveEquation,
 )
-    ocean_timestep!(progn, diagn, ocean_model, model)
+    timestep!(progn, diagn, ocean_model, model)
 end
 
-function ocean_timestep!(
+function timestep!(
     progn::PrognosticVariables,
     diagn::DiagnosticVariables,
     ocean::SeasonalOceanClimatology,
@@ -228,7 +227,7 @@ function initialize!(
     # (seasonal model will be garbage collected hereafter)
 end
 
-function ocean_timestep!(
+function timestep!(
     progn::PrognosticVariables,
     diagn::DiagnosticVariables,
     ocean_model::ConstantOceanClimatology,
@@ -280,7 +279,7 @@ function initialize!(
     ocean_model.mask && mask!(sea_surface_temperature, model.land_sea_mask, :land)
 end
 
-function ocean_timestep!(
+function timestep!(
     progn::PrognosticVariables,
     diagn::DiagnosticVariables,
     ocean_model::AquaPlanet,
@@ -345,7 +344,7 @@ function initialize!(
     ocean_model.mask && mask!(sea_surface_temperature, model.land_sea_mask, :land)
 end
 
-function ocean_timestep!(
+function timestep!(
     progn::PrognosticVariables,
     diagn::DiagnosticVariables,
     ocean_model::SlabOcean,

--- a/src/physics/sea_ice.jl
+++ b/src/physics/sea_ice.jl
@@ -1,29 +1,10 @@
 abstract type AbstractSeaIce <: AbstractModelComponent end
 
-# set all concentration to zero
-function initialize!(
-    ocean::PrognosticVariablesOcean,
-    progn::PrognosticVariables,
-    diagn::DiagnosticVariables,
-    sea_ice_model::Nothing,
-    model::PrimitiveEquation,
-)
-    return nothing
-end
-
 # function barrier for all oceans
 function sea_ice_timestep!( progn::PrognosticVariables,
                             diagn::DiagnosticVariables,
                             model::PrimitiveEquation)
-    sea_ice_timestep!(progn, diagn, model.sea_ice, model)
-end
-
-# Nothing for sea ice does not do anything 
-function sea_ice_timestep!( progn::PrognosticVariables,
-                            diagn::DiagnosticVariables,
-                            sea_ice_model::Nothing,
-                            model::PrimitiveEquation)
-    return nothing
+    timestep!(progn, diagn, model.sea_ice, model)
 end
 
 export ThermodynamicSeaIce
@@ -52,10 +33,10 @@ function initialize!(
     return nothing
 end
 
-function sea_ice_timestep!( progn::PrognosticVariables,
-                            diagn::DiagnosticVariables,
-                            sea_ice_model::ThermodynamicSeaIce,
-                            model::PrimitiveEquation)
+function timestep!( progn::PrognosticVariables,
+                    diagn::DiagnosticVariables,
+                    sea_ice_model::ThermodynamicSeaIce,
+                    model::PrimitiveEquation)
     
     sst = progn.ocean.sea_surface_temperature
     ℵ = progn.ocean.sea_ice_concentration   # sea ice concentration [0, 1] as \aleph yay!

--- a/src/physics/sea_ice.jl
+++ b/src/physics/sea_ice.jl
@@ -1,19 +1,14 @@
 abstract type AbstractSeaIce <: AbstractModelComponent end
 
-export NoSeaIce
-struct NoSeaIce <: AbstractSeaIce end
-NoSeaIce(::SpectralGrid) = NoSeaIce()
-initialize!(::NoSeaIce, ::AbstractModel) = nothing
-
 # set all concentration to zero
 function initialize!(
     ocean::PrognosticVariablesOcean,
     progn::PrognosticVariables,
     diagn::DiagnosticVariables,
-    sea_ice_model::NoSeaIce,
+    sea_ice_model::Nothing,
     model::PrimitiveEquation,
 )
-    ocean.sea_ice_concentration .= 0
+    return nothing
 end
 
 # function barrier for all oceans
@@ -23,10 +18,10 @@ function sea_ice_timestep!( progn::PrognosticVariables,
     sea_ice_timestep!(progn, diagn, model.sea_ice, model)
 end
 
-# NoSeaIce does not do anything 
+# Nothing for sea ice does not do anything 
 function sea_ice_timestep!( progn::PrognosticVariables,
                             diagn::DiagnosticVariables,
-                            sea_ice_model::NoSeaIce,
+                            sea_ice_model::Nothing,
                             model::PrimitiveEquation)
     return nothing
 end

--- a/src/physics/shortwave_radiation.jl
+++ b/src/physics/shortwave_radiation.jl
@@ -11,11 +11,7 @@ function shortwave_radiation!(column::ColumnVariables, model::PrimitiveEquation)
 end
 
 ## NO SHORTWAVE RADIATION
-export NoShortwave
-struct NoShortwave <: AbstractShortwave end
-NoShortwave(SG::SpectralGrid) = NoShortwave()
-initialize!(::NoShortwave, ::PrimitiveEquation) = nothing
-shortwave_radiation!(::ColumnVariables, ::NoShortwave, ::PrimitiveEquation) = nothing
+shortwave_radiation!(::ColumnVariables, ::Nothing, ::PrimitiveEquation) = nothing
 
 ## SHORTWAVE RADIATION FOR A FULLY TRANSPARENT ATMOSPHERE
 export TransparentShortwave

--- a/src/physics/shortwave_radiation.jl
+++ b/src/physics/shortwave_radiation.jl
@@ -1,7 +1,7 @@
 abstract type AbstractShortwave <: AbstractRadiation end
 
-function get_nbands(R::AbstractRadiation)
-    hasfield(typeof(R), :nbands) && return R.nbands
+function get_nbands(radiation::Union{AbstractRadiation, Nothing})
+    hasfield(typeof(radiation), :nbands) && return radiation.nbands
     return 0
 end
 

--- a/src/physics/stochastic_physics.jl
+++ b/src/physics/stochastic_physics.jl
@@ -9,13 +9,9 @@ function perturb_parameterization_tendencies!(column::AbstractColumnVariables, m
     perturb_parameterization_tendencies!(column, model.stochastic_physics, model)
 end
 
-
-export NoStochasticPhysics
-struct NoStochasticPhysics <: AbstractStochasticPhysics end
-NoStochasticPhysics(::SpectralGrid) = NoStochasticPhysics()
-initialize!(::NoStochasticPhysics, ::PrimitiveEquation) = nothing
-perturb_parameterization_inputs!(::ColumnVariables, ::NoStochasticPhysics, ::PrimitiveEquation) = nothing
-perturb_parameterization_tendencies!(::ColumnVariables, ::NoStochasticPhysics, ::PrimitiveEquation) = nothing
+# no perturbations
+perturb_parameterization_inputs!(::ColumnVariables, ::Nothing, ::PrimitiveEquation) = nothing
+perturb_parameterization_tendencies!(::ColumnVariables, ::Nothing, ::PrimitiveEquation) = nothing
 
 export StochasticallyPerturbedParameterizationTendencies
 @kwdef struct StochasticallyPerturbedParameterizationTendencies{NF, VectorType} <: AbstractStochasticPhysics

--- a/src/physics/surface_fluxes/heat.jl
+++ b/src/physics/surface_fluxes/heat.jl
@@ -28,11 +28,8 @@ end
 
 ## ----
 
-export NoSurfaceHeatFlux
-struct NoSurfaceHeatFlux <: AbstractSurfaceHeatFlux end
-NoSurfaceHeatFlux(::SpectralGrid) = NoSurfaceHeatFlux()
-initialize!(::NoSurfaceHeatFlux, ::PrimitiveEquation) = nothing
-surface_heat_flux!(::ColumnVariables, ::NoSurfaceHeatFlux, ::PrimitiveEquation) = nothing
+# no surface heat flux
+surface_heat_flux!(::ColumnVariables, ::Nothing, ::PrimitiveEquation) = nothing
 
 ## ----
 

--- a/src/physics/surface_fluxes/humidity.jl
+++ b/src/physics/surface_fluxes/humidity.jl
@@ -28,11 +28,8 @@ end
 
 ## ----
 
-export NoSurfaceHumidityFlux
-struct NoSurfaceHumidityFlux <: AbstractSurfaceHumidityFlux end
-NoSurfaceHumidityFlux(::SpectralGrid) = NoSurfaceHumidityFlux()
-initialize!(::NoSurfaceHumidityFlux, ::PrimitiveWet) = nothing
-surface_humidity_flux!(::ColumnVariables, ::NoSurfaceHumidityFlux, ::PrimitiveWet) = nothing
+# no surface humidity flux
+surface_humidity_flux!(::ColumnVariables, ::Nothing, ::PrimitiveWet) = nothing
 
 ## ----
 

--- a/src/physics/surface_fluxes/momentum.jl
+++ b/src/physics/surface_fluxes/momentum.jl
@@ -1,8 +1,5 @@
-export NoSurfaceWind
-struct NoSurfaceWind <: AbstractSurfaceWind end
-NoSurfaceWind(::SpectralGrid) = NoSurfaceWind()
-initialize!(::NoSurfaceWind, ::PrimitiveEquation) = nothing
-surface_wind_stress!(::ColumnVariables, ::NoSurfaceWind, ::PrimitiveEquation) = nothing
+# no surface wind stress
+surface_wind_stress!(::ColumnVariables, ::Nothing, ::PrimitiveEquation) = nothing
 
 export SurfaceWind
 Base.@kwdef struct SurfaceWind{NF<:AbstractFloat} <: AbstractSurfaceWind

--- a/src/physics/surface_fluxes/surface_fluxes.jl
+++ b/src/physics/surface_fluxes/surface_fluxes.jl
@@ -3,6 +3,10 @@ abstract type AbstractSurfaceWind <: AbstractParameterization end
 abstract type AbstractSurfaceHeatFlux <: AbstractParameterization end
 abstract type AbstractSurfaceHumidityFlux <: AbstractParameterization end
 
+# skip immediately for sensi_heat_flux or 
+surface_heat_flux!(c::ColumnVariables, f::Nothing, ::PrognosticVariables, ::PrimitiveEquation) = nothing
+surface_humidity_flux!(c::ColumnVariables, f::Nothing, ::PrognosticVariables, ::PrimitiveEquation) = nothing
+
 # skip the prognostic variables if not defined (needed to read in prescribed fluxes)
 surface_heat_flux!(c::ColumnVariables, f::AbstractSurfaceHeatFlux,
     p::PrognosticVariables, m::PrimitiveEquation) = surface_heat_flux!(c, f, m)

--- a/src/physics/temperature_relaxation.jl
+++ b/src/physics/temperature_relaxation.jl
@@ -5,11 +5,8 @@ function temperature_relaxation!(column::ColumnVariables, model::PrimitiveEquati
     temperature_relaxation!(column, model.temperature_relaxation, model)
 end
 
-export NoTemperatureRelaxation
-struct NoTemperatureRelaxation <: AbstractTemperatureRelaxation end
-NoTemperatureRelaxation(::SpectralGrid) = NoTemperatureRelaxation()
-initialize!(::NoTemperatureRelaxation, ::PrimitiveEquation) = nothing
-temperature_relaxation!(::ColumnVariables, ::NoTemperatureRelaxation, ::PrimitiveEquation) = nothing
+# no temperature relaxation
+temperature_relaxation!(::ColumnVariables, ::Nothing, ::PrimitiveEquation) = nothing
 
 export HeldSuarez
 

--- a/src/physics/vertical_diffusion.jl
+++ b/src/physics/vertical_diffusion.jl
@@ -7,13 +7,7 @@ function vertical_diffusion!(   column::ColumnVariables,
 end
 
 ## NO VERTICAL DIFFUSION
-export NoVerticalDiffusion
-struct NoVerticalDiffusion <: AbstractVerticalDiffusion end
-NoVerticalDiffusion(SG::SpectralGrid) = NoVerticalDiffusion()
-
-# define dummy functions
-initialize!(::NoVerticalDiffusion,::PrimitiveEquation) = nothing
-vertical_diffusion!(::ColumnVariables, ::NoVerticalDiffusion, ::PrimitiveEquation) = nothing
+vertical_diffusion!(::ColumnVariables, ::Nothing, ::PrimitiveEquation) = nothing
 
 export BulkRichardsonDiffusion
 @kwdef struct BulkRichardsonDiffusion{NF, VectorType} <: AbstractVerticalDiffusion

--- a/test/physics/convection.jl
+++ b/test/physics/convection.jl
@@ -2,7 +2,7 @@
     
     spectral_grid = SpectralGrid(trunc=31, nlayers=8)
 
-    for Convection in ( NoConvection,
+    for Convection in ( Nothing,
                         SimplifiedBettsMiller,
                         DryBettsMiller,
                         ConvectiveHeating)

--- a/test/physics/land.jl
+++ b/test/physics/land.jl
@@ -21,7 +21,7 @@ end
     spectral_grid = SpectralGrid(trunc=31, nlayers=8)
 
     for Temperature in (SeasonalLandTemperature, ConstantLandTemperature, LandBucketTemperature)
-        for SoilMoisture in (NoSoilMoisture, SeasonalSoilMoisture, LandBucketMoisture)
+        for SoilMoisture in (Nothing, SeasonalSoilMoisture, LandBucketMoisture)
             for Vegetation in (NoVegetation, VegetationClimatology)
                 for Model in (PrimitiveDryModel, PrimitiveWetModel)
 

--- a/test/physics/ocean_sea_ice.jl
+++ b/test/physics/ocean_sea_ice.jl
@@ -12,7 +12,7 @@
                             SlabOcean)
 
         @testset for SeaIceModel in (ThermodynamicSeaIce,
-                                 NoSeaIce)
+                                        Nothing)
 
             ocean = OceanModel(spectral_grid)
             sea_ice = SeaIceModel(spectral_grid)
@@ -28,7 +28,7 @@
             @test all(0 .<= simulation.prognostic_variables.ocean.sea_ice_concentration .<= 1)
             @test all(0 .<= simulation.diagnostic_variables.physics.ocean.albedo .<= 1)
 
-            if sea_ice isa NoSeaIce
+            if sea_ice isa Nothing
                 @test all(simulation.prognostic_variables.ocean.sea_ice_concentration .== 0)
             end
         end

--- a/test/physics/radiation.jl
+++ b/test/physics/radiation.jl
@@ -2,7 +2,7 @@
 
     spectral_grid = SpectralGrid(trunc=31, nlayers=5)
 
-    for Radiation in (NoLongwave,
+    for Radiation in (  Nothing,
                         UniformCooling,
                         JeevanjeeRadiation)
 


### PR DESCRIPTION
So that `convection = nothing` etc is possible, removes a lot of code redundancy as `NoSeaIce`, `NoConvection` etc don't have to be defined anymore. Current exceptions are

- `NoOrography` which contains zeros arrays
- `NoVegetation` as this still needs to compute the soil moisture availability and dispatching over `Nothing` here seems ambiguous (maybe there's a way to resolve this but maybe not so important for now?)

