### PR TITLE
Bug? Reset geopotential accumulator in implicit correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reset geopotential accumulator in implicit correction [#890](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/890)
 - Zenith constructors [#889](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/889)
 - More general forcing of pressure, vorticity and divergence [#855](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/855)
 

--- a/src/dynamics/implicit.jl
+++ b/src/dynamics/implicit.jl
@@ -317,6 +317,7 @@ function implicit_correction!(
     (; pres_tend, div_tend) = diagn.tendencies
     G = diagn.dynamics.a        # reuse work arrays, used for combined tendency G
     geopot = diagn.dynamics.b   # used for geopotential
+    geopot .= 0                 # reset geopotential accumulator
 
     for k in 1:nlayers
         for r in k:nlayers      # skip 1:k-1 as integration is surface to k


### PR DESCRIPTION
Found by @maximilian-gelbrecht 

`dynamics.b` is used to hold `v*q` the northward humidity flux before ... it's weird it's been stable the past 2.5 years but on the other hand the original idea for these semi-implicit corrections is that one uses no orography but I never quite understood why because I believe one could just use surface geopotential as a starting condition for this integration. So maybe we just did a semi-implicit correction relative to an "orography" = `v*q` that was even changing with time ...  Maybe that was also the reason why more vertical layers always caused problems ... I will come up with a testcase and check whether `geopot .= 0` or `geopot[:, end] .= geopot_surf` is better!