### PR TITLE
Show for LowerTriangularArray/Matrix on CPU/GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Show for LowerTriangularArray/Matrix on CPU/GPU [#907](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/907)
 - Ring, nested and matrix order for OctaHEALPixGrid [#887](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/887)
 - Fixes a bug in the allocating spectral transforms on GPU [#906](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/906)
 - ScratchMemory allocation bug [#905](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/905)

--- a/LowerTriangularArrays/src/lower_triangular_array.jl
+++ b/LowerTriangularArrays/src/lower_triangular_array.jl
@@ -141,7 +141,7 @@ end
 
 function Base.array_summary(io::IO, ::LowerTriangularArray{T, N, A}, inds::Tuple{Vararg{Base.OneTo}}) where {T, N, A}
     A_ = nonparametric_type(A)
-    print(io, Base.dims2string(length.(inds)), "LowerTriangularArray{$T, $N, $A_{...}}")
+    print(io, Base.dims2string(length.(inds)), " LowerTriangularArray{$T, $N, $A_{...}}")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", L::LowerTriangularArray)


### PR DESCRIPTION
With 
```julia
using SpeedyWeather, CUDA
S = Spectrum(33, 32, architecture=GPU())
L = randn(ComplexF32, S)
```
we had an error of the actual array because the `on_architecture(CPU(), L)` wasn't kicking in. Now I've also streamlined the type info which was previously on CPU/GPU quite lengthy e.g.
```julia
julia> L = randn(ComplexF32, S, 8)
560×8 LowerTriangularArray{ComplexF32, 2, Matrix{ComplexF32}, Spectrum{CPU{KernelAbstractions.CPU}, Vector{UnitRange{Int64}}, Vector{Int64}}}
...
```

now this prints shorter as

```julia
# on GPU
julia> L = randn(ComplexF32, S)
560-element, 33x32 LowerTriangularMatrix{ComplexF32, CuArray{...}}
...
julia> L = randn(ComplexF32, S, 8)
560×8 LowerTriangularArray{ComplexF32, 2, CuArray{...}}
...
# on CPU
julia> L = randn(ComplexF32, S)
560-element, 33x32 LowerTriangularMatrix{ComplexF32, Array{...}}
...
julia> L = randn(ComplexF32, S, 8)
560×8 LowerTriangularArray{ComplexF32, 2, Array{...}}
```

so just the `Array{...}` or `CuArray{...}` which I believe is enough information. One can still do
```julia
julia> typeof(L)
LowerTriangularMatrix{ComplexF32, CuArray{ComplexF32, 1, DeviceMemory}, Spectrum{GPU{CUDABackend}, CuArray{UnitRange{Int64}, 1, DeviceMemory}, CuArray{Int64, 1, DeviceMemory}}} (alias for LowerTriangularArray{Complex{Float32}, 1, CuArray{Complex{Float32}, 1, CUDA.DeviceMemory}, Spectrum{GPU{CUDABackend}, CuArray{UnitRange{Int64}, 1, CUDA.DeviceMemory}, CuArray{Int64, 1, CUDA.DeviceMemory}}})
```
if the full information is needed.

@gregordecristoforo I think we hit this error on Monday too