### PR TITLE
Update docs CairoMakie compatibility to "0.12, 0.13, 0.14, 0.15"

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -18,7 +18,7 @@ SpeedyTransforms = {path = "../SpeedyTransforms"}
 SpeedyWeather = {path = ".."}
 
 [compat]
-CairoMakie = "0.12"
+CairoMakie = "0.12, 0.13, 0.14, 0.15"
 Documenter = "0.26, 0.27, 1"
 GeoMakie = "0.7.6"
 NCDatasets = "0.12, 0.13, 0.14"


### PR DESCRIPTION
This pull request updates the compatibility entry for CairoMakie in Project.tom to support versions 0.12, 0.13, 0.14, and 0.15. 