### PR TITLE
Add entrainment profiles to Betts-Miller convection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+- Add entrainment profiles to Betts-Miller convection [#976](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/976)
 - Particle advection GPU ready [#897](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/897)
 - Enzyme compat relaxed as Enzyme bug was fixed and uv_from_vordiv! kernel version used on CPU as well [#971](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/971)
 - GitHub Actions: Cache updated [#945](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/945)

--- a/SpeedyWeather/src/physics/convection.jl
+++ b/SpeedyWeather/src/physics/convection.jl
@@ -304,7 +304,7 @@ The simplified Betts-Miller convection scheme from Frierson, 2007,
 https://doi.org/10.1175/JAS3935.1 but with humidity set to zero.
 Fields and options are
 $(TYPEDFIELDS)"""
-@kwdef struct BettsMillerDryConvection{NF, Entrainment <: AbstractEntrainment} <: AbstractConvection
+@parameterized @kwdef struct BettsMillerDryConvection{NF, Entrainment <: AbstractEntrainment} <: AbstractConvection
     "[OPTION] Relaxation time for profile adjustment"
     time_scale::Second = Hour(4)
 


### PR DESCRIPTION
## Summary
- add `AbstractEntrainment` with `LinearEntrainment` and `ConstantEntrainment` profiles
- wire entrainment into `BettsMillerConvection` and pass it to `pseudo_adiabat!`
- apply entrainment mixing in the moist ascent calculation
