### PR TITLE
Add get_output_path(::Simulation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `get_output_path(::Simulation)` to retrieve the output file path [#1011](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1011)
 - GitHub `actions/setup-node` updated to v6 [#1009](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1009)
 - Documentation for `MatrixSpectralTransform` added to SpeedyTransforms docs [#1006](https://github.com/SpeedyWeather/SpeedyWeather.jl/issues/1006)
 - MatrixSpectralTransform implemented [#952](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/952)

--- a/SpeedyWeather/src/output/netcdf_output.jl
+++ b/SpeedyWeather/src/output/netcdf_output.jl
@@ -528,6 +528,14 @@ Returns the full path of the output file after it was created."""
 get_full_output_file_path(output::AbstractOutput) = joinpath(output.run_path, output.filename)
 
 """$(TYPEDSIGNATURES)
+Returns the full path of the output file for a `simulation`. Throws an error if output is not active."""
+function get_output_path(simulation::AbstractSimulation)
+    output = simulation.model.output
+    output.active || error("Output is not active")
+    return joinpath(output.run_path, output.filename)
+end
+
+"""$(TYPEDSIGNATURES)
 Loads a `var_name` trajectory of the model `M` that has been saved in
 a netCDF file during the time stepping."""
 function load_trajectory(var_name::Union{Symbol, String}, model::AbstractModel)

--- a/SpeedyWeather/test/output/netcdf_output.jl
+++ b/SpeedyWeather/test/output/netcdf_output.jl
@@ -269,3 +269,22 @@ end
     @test t == manual_time_axis(model.output.startdate, model.time_stepping.Δt_millisec, progn.clock.n_timesteps)
     @test t == SpeedyWeather.load_trajectory("time", model)
 end
+
+@testset "get_output_path" begin
+    tmp_output_path = mktempdir(pwd(), prefix = "tmp_testruns_")
+
+    # output inactive: should throw an error
+    spectral_grid = SpectralGrid(nlayers = 1)
+    model = BarotropicModel(spectral_grid)
+    simulation = initialize!(model)
+    @test_throws ErrorException SpeedyWeather.get_output_path(simulation)
+
+    # output active: should return the correct path
+    output = NetCDFOutput(spectral_grid, path = tmp_output_path)
+    model = BarotropicModel(spectral_grid; output)
+    simulation = initialize!(model)
+    run!(simulation, output = true, period = Day(1))
+    expected_path = joinpath(simulation.model.output.run_path, simulation.model.output.filename)
+    @test SpeedyWeather.get_output_path(simulation) == expected_path
+    @test isfile(SpeedyWeather.get_output_path(simulation))
+end


### PR DESCRIPTION
Closes #1011.

## Summary

- Adds `get_output_path(simulation::Simulation)` to `netcdf_output.jl` that returns `joinpath(simulation.model.output.run_path, simulation.model.output.filename)`
- Throws an `ErrorException` with message `"Output is not active"` if `output.active` is `false`
- Adds a `@testset "get_output_path"` in `SpeedyWeather/test/output/netcdf_output.jl` covering both the inactive (error) and active (correct path) cases

## Test plan

- [ ] `@test_throws ErrorException SpeedyWeather.get_output_path(simulation)` when output is not active
- [ ] `SpeedyWeather.get_output_path(simulation)` returns correct path and file exists after a run with `output=true`