### PR TITLE
Batch 2D spectral→grid transforms in pressure_gradient_flux! for GPU efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Batch two 2D spectral→grid transforms in `pressure_gradient_flux!` into one 3D transform for GPU efficiency [#1012](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1012)
 - GitHub `actions/setup-node` updated to v6 [#1009](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1009)
 - Documentation for `MatrixSpectralTransform` added to SpeedyTransforms docs [#1006](https://github.com/SpeedyWeather/SpeedyWeather.jl/issues/1006)
 - MatrixSpectralTransform implemented [#952](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/952)

--- a/SpeedyTransforms/src/spectral_gradients.jl
+++ b/SpeedyTransforms/src/spectral_gradients.jl
@@ -526,6 +526,59 @@ end
     end
 end
 
+"""$(TYPEDSIGNATURES)
+Applies the gradient operator ∇ to the 2D input `p` and stores the zonal derivative
+in layer 1 and the meridional derivative in layer 2 of the 3D output array `dpdxy`.
+The gradient operator acts on the unit sphere and therefore omits the 1/radius scaling
+unless `radius` keyword argument is provided.
+This batched form avoids two separate spectral→grid transforms by computing both
+gradient components into a single 3D array that can be transformed in one call."""
+function ∇!(
+        dpdxy::LowerTriangularArray,            # Output: 3D, layer 1 = zonal, layer 2 = meridional gradient
+        p::LowerTriangularArray,                # Input: 2D spectral coefficients
+        S::AbstractSpectralTransform;           # includes precomputed arrays
+        radius = DEFAULT_RADIUS,                # scale with radius if provided, otherwise unit sphere
+    )
+    @boundscheck ismatching(S, p) || throw(DimensionMismatch(S, p))
+    @boundscheck size(dpdxy, 2) >= 2 || throw(DimensionMismatch("dpdxy must have at least 2 layers"))
+
+    (; grad_y1, grad_y2) = S.gradients
+    (; m_indices) = p.spectrum
+
+    launch!(architecture(dpdxy), SpectralWorkOrder, size(dpdxy), ∇_kernel!, dpdxy, p.data, m_indices, grad_y1, grad_y2)
+
+    # 1/radius factor if not unit sphere
+    if radius != 1
+        dpdxy .*= inv(radius)
+    end
+
+    return dpdxy
+end
+
+@kernel inbounds = true function ∇_kernel!(dpdxy, p, m_indices, grad_y1, grad_y2)
+    I = @index(Global, Cartesian)
+    lm = I[1]
+    k = I[2]
+    lmmax = size(dpdxy, 1)
+
+    # only compute for layer 1 (x) and layer 2 (y); ignore higher layers if present
+    if k == 1
+        # zonal gradient: dpdx = im*(m-1)*p
+        dpdxy[lm, 1] = complex(0, m_indices[lm] - 1) * p[lm]
+    elseif k == 2
+        # meridional gradient using grad_y precomputed coefficients
+        gy1 = grad_y1[lm]
+        gy2 = grad_y2[lm]
+        if lm == 1
+            dpdxy[lm, 2] = gy2 * p[lm + 1]
+        elseif lm == lmmax
+            dpdxy[lm, 2] = gy1 * p[lm - 1]
+        else
+            dpdxy[lm, 2] = gy1 * p[lm - 1] + gy2 * p[lm + 1]
+        end
+    end
+end
+
 """$(TYPEDSIGNATURES) The zonal and meridional gradient of `p`
 using an existing `SpectralTransform` `S`. Acts on the unit sphere,
 i.e. it omits 1/radius scaling unless `radius` keyword argument is provided."""

--- a/SpeedyWeather/src/dynamics/tendencies.jl
+++ b/SpeedyWeather/src/dynamics/tendencies.jl
@@ -125,15 +125,17 @@ function pressure_gradient_flux!(
 
     (; scratch_memory) = diagn.dynamics
 
-    # PRESSURE GRADIENT
-    pres = get_step(progn.pres, lf)         # log of surface pressure at leapfrog step lf
-    ∇lnp_x_spec = diagn.dynamics.a_2D       # reuse 2D work arrays for gradients
-    ∇lnp_y_spec = diagn.dynamics.b_2D       # in spectral space
-    (; ∇lnp_x, ∇lnp_y) = diagn.dynamics     # but store in grid space
+    # PRESSURE GRADIENT: batched spectral gradient + single 3D transform (GPU-friendly)
+    pres = get_step(progn.pres, lf)                  # log of surface pressure at leapfrog step lf
+    (; ∇lnp_spec, ∇lnp_grid) = diagn.dynamics        # 2-layer arrays: layer 1 = zonal, layer 2 = meridional
+    (; ∇lnp_x, ∇lnp_y) = diagn.dynamics              # 2D grid arrays (read by other tendency functions)
 
-    ∇!(∇lnp_x_spec, ∇lnp_y_spec, pres, S)                   # CALCULATE ∇ln(pₛ)
-    transform!(∇lnp_x, ∇lnp_x_spec, scratch_memory, S, unscale_coslat = true) # transform to grid: zonal gradient
-    transform!(∇lnp_y, ∇lnp_y_spec, scratch_memory, S, unscale_coslat = true) # meridional gradient
+    ∇!(∇lnp_spec, pres, S)                           # CALCULATE ∇ln(pₛ): layer 1 = zonal, layer 2 = meridional
+    transform!(∇lnp_grid, ∇lnp_spec, scratch_memory, S, unscale_coslat = true)  # single 3D transform
+
+    # copy 2-layer result into the 2D ∇lnp_x, ∇lnp_y fields used throughout the dynamical core
+    ∇lnp_x.data .= view(∇lnp_grid.data, :, 1)
+    ∇lnp_y.data .= view(∇lnp_grid.data, :, 2)
 
     (; u_grid, v_grid) = diagn.grid
     (; uv∇lnp) = diagn.dynamics
@@ -339,6 +341,14 @@ function surface_pressure_tendency!(
     @. pres_tend_grid += u_mean_grid * ∇lnp_x + v_mean_grid * ∇lnp_y
 
     ūv̄∇lnpₛ = diagn.dynamics.a_2D           # reuse 2D work array
+
+    # TODO (issue #947): This grid→spectral transform is the 3rd single-level transform
+    # that could be batched for GPU efficiency. A possible approach: combine `pres_tend_grid`
+    # and another 2D field into a 2-layer array and perform one 3D transform. However,
+    # `pres_tend_grid` accumulates forcing contributions before this point and `div_mean`
+    # is accumulated in spectral space in `vertical_integration!` at the semi-implicit lf=1
+    # step. Batching would require restructuring the forcing accumulation and the semi-implicit
+    # splitting. Do not implement without further design and agreement.
     transform!(ūv̄∇lnpₛ, pres_tend_grid, scratch_memory, S)
 
     # for semi-implicit div_mean is calc at time step i-1 in vertical_integration!

--- a/SpeedyWeather/src/variables/diagnostic_variables.jl
+++ b/SpeedyWeather/src/variables/diagnostic_variables.jl
@@ -238,6 +238,12 @@ $(TYPEDFIELDS)"""
     "Meridional gradient of log surf pressure"
     ∇lnp_y::GridVariable2D = zeros(GridVariable2D, grid)
 
+    "Gradient of log surf pressure, spectral, both components batched: layer 1 = zonal, layer 2 = meridional"
+    ∇lnp_spec::SpectralVariable3D = zeros(SpectralVariable3D, spectrum, 2)
+
+    "Gradient of log surf pressure, grid, both components batched: layer 1 = zonal, layer 2 = meridional"
+    ∇lnp_grid::GridVariable3D = zeros(GridVariable3D, grid, 2)
+
     "Vertical average of zonal velocity [m/s]"
     u_mean_grid::GridVariable2D = zeros(GridVariable2D, grid)
 


### PR DESCRIPTION
## Summary

Closes #947 (partially — the 3rd transform is deferred, see plan comment below).

In `pressure_gradient_flux!`, the two consecutive spectral→grid transforms for the zonal and meridional components of ∇ln(pₛ) are batched into a single 3D transform. This reduces kernel launches and improves GPU utilisation by parallelising both components in one call.

### Changes

- **`DynamicsVariables`** (`diagnostic_variables.jl`): Add `∇lnp_spec` (2-layer `SpectralVariable3D`) and `∇lnp_grid` (2-layer `GridVariable3D`) to hold both gradient components in a single batched array.
- **SpeedyTransforms** (`spectral_gradients.jl`): Add a new `∇!(dpdxy, p, S)` overload (and `∇_kernel!` kernel) that writes the zonal gradient into layer 1 and the meridional gradient into layer 2 of the 3D output array. The existing two-output `∇!(dpdx, dpdy, p, S)` is unchanged.
- **`pressure_gradient_flux!`** (`tendencies.jl`): Use the new batched path — one `∇!` call into `∇lnp_spec`, then one 3D `transform!` into `∇lnp_grid`. Afterwards copy layer 1 → `∇lnp_x` and layer 2 → `∇lnp_y` so all downstream code that reads those 2D fields continues to work unchanged.
- **TODO comment** in `surface_pressure_tendency!`: Describes the plan for batching the 3rd single-level transform (the `pres_tend_grid` grid→spectral transform), with an explanation of why it requires more structural changes and should be agreed upon before implementation.

### How it works on GPU

The inverse Legendre transform on GPU is launched as a single kernel over `jm_index_size * nlayers` threads. With 2 layers batched, this kernel processes both gradient components in parallel with twice the parallelism compared to two separate 1-layer transforms. The FFT falls back to the serial path (one ring at a time) since `nlayers=2 ≠ S.nlayers`, but the overall reduction in kernel overhead and the Legendre parallelism improvement still benefit GPU execution.

## Test plan

- [ ] Run `julia --project=SpeedyWeather SpeedyWeather/test/runtests.jl` to verify no regressions in the full test suite
- [ ] Confirm that `PrimitiveDry` and `PrimitiveWet` model simulations still produce correct results (the `run_speedy.jl` test covers this)
- [ ] Verify that `DynamicsVariables` shows the new `∇lnp_spec` and `∇lnp_grid` fields when printed
- [ ] GPU: run a short PrimitiveWet simulation on GPU to confirm the 3D transform path works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)