### PR TITLE
RossbyHaurwitz wave example without forcing or drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- RossbyHaurwitz initial condition example corrected [#1027](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1027)
 - [BREAKING] model.dyanmics_only instead of .physics [#969](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/969)
 - [BREAKING] Kernel launching now in SpeedyWeatherInternals.KernelLaunching [#969](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/969)
 - Pretty printing with StyledStrings [#969](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/969)

--- a/docs/src/initial_conditions.md
+++ b/docs/src/initial_conditions.md
@@ -21,13 +21,12 @@ methods simply as 1, 2, 3.
 
 ## Rossby-Haurwitz wave in a BarotropicModel
 
-We define a `BarotropicModel` of some resolution but keep all its components
-as default
+We define a `BarotropicModel` of some resolution without forcing and drag
 
 ```@example haurwitz
 using SpeedyWeather
 spectral_grid = SpectralGrid(trunc=63, nlayers=1)
-model = BarotropicModel(spectral_grid)
+model = BarotropicModel(spectral_grid, forcing=nothing, drag=nothing)
 simulation = initialize!(model)
 ```
 
@@ -162,7 +161,9 @@ Rossby-Haurwitz wave in the shallow water model without any influences from orog
 spectral_grid = SpectralGrid(trunc=63, nlayers=1)
 initial_conditions = RossbyHaurwitzWave(spectral_grid)
 orography = NoOrography(spectral_grid)
-model = ShallowWaterModel(; spectral_grid, initial_conditions, orography)
+forcing = nothing
+drag = nothing
+model = ShallowWaterModel(spectral_grid; forcing, drag, initial_conditions, orography)
 simulation = initialize!(model)
 run!(simulation, period=Day(8))
 
@@ -204,7 +205,10 @@ initial_conditions = (;
 orography = NoOrography(spectral_grid)
 time_stepping = Leapfrog(spectral_grid, Δt_at_T31=Minute(30))   # 30min timestep scaled linearly
 
-model = PrimitiveDryModel(spectral_grid; time_stepping, initial_conditions, orography, dynamics_only=false)
+forcing = nothing
+drag = nothing
+
+model = PrimitiveDryModel(spectral_grid; time_stepping, initial_conditions, orography, forcing, drag, dynamics_only=false)
 simulation = initialize!(model)
 run!(simulation, period=Day(5))
 nothing # hide


### PR DESCRIPTION
The Rossby Haurwitz wave example initial conditions in the docs

<img width="1250" height="600" alt="image" src="https://github.com/user-attachments/assets/23752a07-c671-4f90-8f0f-d99781a0dfd0" />

don't actually maintain shape while propagating longitudinally at the moment:

<img width="1250" height="600" alt="image" src="https://github.com/user-attachments/assets/183a7a3e-bb6f-437c-b845-fe62041531d5" />

Likely because we haven't actually switched off forcing and drag in this example