### PR TITLE
Make default KolmogorovFlow weaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Make default KolmogorovFlow weaker [#1030](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1030)
 - GitHub Action Cache updated to v3 [#1029](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1029)
 - RossbyHaurwitz initial condition example corrected [#1027](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1027)
 - [BREAKING] model.dyanmics_only instead of .physics [#969](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/969)

--- a/SpeedyWeather/src/dynamics/forcing.jl
+++ b/SpeedyWeather/src/dynamics/forcing.jl
@@ -229,7 +229,7 @@ $(TYPEDFIELDS)
 """
 @parameterized @kwdef mutable struct KolmogorovFlow{NF} <: AbstractForcing
     "[OPTION] Strength of forcing [1/s²]"
-    @param strength::NF = 5.0e-5 (bounds = Nonnegative,)
+    @param strength::NF = 2.0e-5 (bounds = Real,)
 
     "[OPTION] Wavenumber of forcing in meridional direction (pole to pole)"
     @param wavenumber::NF = 8 (bounds = Nonnegative,)

--- a/SpeedyWeather/test/dynamics/run_defaults.jl
+++ b/SpeedyWeather/test/dynamics/run_defaults.jl
@@ -1,31 +1,36 @@
 @testset "run defaults for a year, no blow up" begin
-    # Barotropic
-    spectral_grid = SpectralGrid(nlayers = 1)
-    model = BarotropicModel(spectral_grid)
-    simulation = initialize!(model)
-    run!(simulation, period = Year(1))
-    @test simulation.model.feedback.nans_detected == false
 
-    # ShallowWater
-    spectral_grid = SpectralGrid(nlayers = 1)
-    model = ShallowWaterModel(spectral_grid)
-    simulation = initialize!(model)
-    run!(simulation, period = Year(1))
-    @test simulation.model.feedback.nans_detected == false
+    @testset "BarotropicModel" begin
+        spectral_grid = SpectralGrid(nlayers = 1)
+        model = BarotropicModel(spectral_grid)
+        simulation = initialize!(model)
+        run!(simulation, period = Year(1))
+        @test simulation.model.feedback.nans_detected == false
+    end
 
-    # PrimitiveDry
-    spectral_grid = SpectralGrid()
-    model = PrimitiveDryModel(spectral_grid)
-    simulation = initialize!(model)
-    run!(simulation, period = Year(1))
-    @test simulation.model.feedback.nans_detected == false
+    @testset "ShallowWaterModel" begin
+        spectral_grid = SpectralGrid(nlayers = 1)
+        model = ShallowWaterModel(spectral_grid)
+        simulation = initialize!(model)
+        run!(simulation, period = Year(1))
+        @test simulation.model.feedback.nans_detected == false
+    end
 
-    # PrimitiveWet
-    spectral_grid = SpectralGrid()
-    model = PrimitiveWetModel(spectral_grid)
-    simulation = initialize!(model)
-    run!(simulation, period = Year(1))
-    @test simulation.model.feedback.nans_detected == false
+    @testset "PrimitiveDryModel" begin
+        spectral_grid = SpectralGrid()
+        model = PrimitiveDryModel(spectral_grid)
+        simulation = initialize!(model)
+        run!(simulation, period = Year(1))
+        @test simulation.model.feedback.nans_detected == false
+    end
+
+    @testset "PrimitiveWetModel" begin
+        spectral_grid = SpectralGrid()
+        model = PrimitiveWetModel(spectral_grid)
+        simulation = initialize!(model)
+        run!(simulation, period = Year(1))
+        @test simulation.model.feedback.nans_detected == false
+    end
 end
 
 @testset "run defaults with MatrixSpectralTransform, no blow up" begin


### PR DESCRIPTION
Since #969 the BarotropicModel had some instabilities because the KolmogorovFlow somehow was too strong, easily exceeding 120m/s in the first year of simulation. This turns its strength from 5e-5 to 2e-5

<img width="919" height="414" alt="image" src="https://github.com/user-attachments/assets/3dcb7e83-f5c4-41c7-9986-1367da491d2a" />

better now

<img width="915" height="414" alt="image" src="https://github.com/user-attachments/assets/83585c33-7108-4ae7-8bf4-604a4feddc06" />
