### PR TITLE
remove manual installation of node in docs ci workflow

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -18,18 +18,13 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: '1.12'
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: docs/package.json
-      - name: Install Node.js dependencies
-        run: npm install
-        working-directory: docs
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v2
+      - name: Load Julia packages from cache
+        id: julia-cache
+        uses: julia-actions/cache@v2
       - name: Install Julia dependencies
         run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path = "SpeedyWeather")); Pkg.instantiate()'
       - name: Build and deploy

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -2,7 +2,7 @@
 
 Generally, SpeedyWeather is built in a very modular, extensible way.
 While that sounds fantastic in general, it does not save you from understanding
-its [modular logic](@ref logic) before you can extend SpeedyWeather.jl easily yourself.
+its [modular logic](@ref logic) before you can extend SpeedyWeather easily yourself.
 We highly recommend you to read the following sections if you would like to
 extend SpeedyWeather in some way, but it also gives you a good understanding
 of how we build SpeedyWeather in the first place. Because in the end there


### PR DESCRIPTION
what's in this PR?

- it removes the `node` step installation, DocumenterVitepress takes care of this internally.
- a small update to `extensions.md` to force an update on the generation of assets (js files mainly). Related to #1038 