### PR TITLE
(0.17.5) update SpeedyWeatherInternals compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpeedyWeather"
 uuid = "9e226e20-d153-4fed-8a5b-493def4f21a9"
 authors = ["SpeedyWeather contributors"]
-version = "0.17.4"
+version = "0.17.5"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -74,7 +74,7 @@ ProgressMeter = "1.7"
 Random = "1.10"
 RingGrids = "0.1"
 SpeedyTransforms = "0.1"
-SpeedyWeatherInternals = "0.1"
+SpeedyWeatherInternals = "0.1.2"
 Statistics = "1.10"
 TOML = "1"
 UnicodePlots = "3.3"


### PR DESCRIPTION
The compat bound in SpeedyWeather v0.17.4 is `SpeedyWeatherInternals = "0.1"`, but SpeedyParameters was only introduced in v0.1.2. SpeedyWeather tries to access SpeedyParameters via SpeedyWeatherInternals in 0.17.4, so this results in a precompilation error when using e.g. SW 0.17.4 and SWI 0.1.0. E.g. see the error in ClimaOcean [here](https://github.com/CliMA/ClimaOcean.jl/actions/runs/24906975982/job/72938721708?pr=785).

This PR updates the SWI compat to 0.1.2 and tags a backported 0.17.5 release. It isn't intended to be merged into main, just used to tag the release.