### PR TITLE
Fix some docs rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased 
+## Unreleased
+
+- Fix some docs rendering [#1072](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1072)
 
 ## v0.19.0
 
@@ -66,7 +68,7 @@
 - Particle advection GPU ready [#897](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/897)
 - Enzyme compat relaxed as Enzyme bug was fixed and uv_from_vordiv! kernel version used on CPU as well [#971](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/971)
 - GitHub Actions: Cache updated [#945](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/945)
-- The number of soil layers is now solely defined by the land model and not in the `SpectralGrid` anymore [#898](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/898)   
+- The number of soil layers is now solely defined by the land model and not in the `SpectralGrid` anymore [#898](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/898)
 - Revised GPU benchmarks to include full GPU models [#946](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/946) and the dynamical core [#967](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/967)
 - Label-based modular skip CI mechanism for github and buildkite [#957](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/957)
 - Monorepo structure and separate tests [#957](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/957)

--- a/docs/src/barotropic.md
+++ b/docs/src/barotropic.md
@@ -21,7 +21,7 @@ relative vorticity ``\zeta`` with advection, Coriolis force, forcing and diffusi
 single global layer on the sphere.
 
 ```math
-\frac{\partial \zeta}{\partial t} + \nabla \cdot (\mathbf{u}(\zeta + f)) =
+\frac{\partial \zeta}{\partial t} + \nabla \cdot [\mathbf{u}(\zeta + f)] =
 F_\zeta + \nabla \times \mathbf{F}_\mathbf{u} + (-1)^{n+1}\nu\nabla^{2n}\zeta
 ```
 We denote time ``t``, velocity vector ``\mathbf{u} = (u, v)``, Coriolis parameter ``f``,
@@ -55,7 +55,7 @@ advect the absolute vorticity ``\zeta + f``. In order to avoid to calculate both
 divergence of a flux we rewrite the barotropic vorticity equation as
 ```math
 \frac{\partial \zeta}{\partial t} = F_\zeta +
-\nabla \times (\mathbf{F}_\mathbf{u} + \mathbf{u}_\perp(\zeta + f)) + (-1)^{n+1}\nu\nabla^{2n}\zeta
+\nabla \times [\mathbf{F}_\mathbf{u} + \mathbf{u}_\perp(\zeta + f)] + (-1)^{n+1}\nu\nabla^{2n}\zeta
 ```
 with ``\mathbf{u}_\perp = (v, -u)`` the rotated velocity vector, because
 ``-\nabla\cdot\mathbf{u} = \nabla \times \mathbf{u}_\perp``. This is the form that is solved
@@ -93,8 +93,8 @@ Now loop over
 In SpeedyWeather.jl we use hyperdiffusion through an ``n``-th power Laplacian ``(-1)^{n+1}\nabla^{2n}``
 (hyper when ``n>1``) which
 can be implemented as a multiplication of the spectral coefficients ``\Psi_{lm}`` with
-``(-l(l+1))^nR^{-2n}`` (see spectral [Laplacian](@ref)). It is therefore computationally not more
-expensive to apply hyperdiffusion over diffusion as the ``(-l(l+1))^nR^{-2n}`` can be precomputed.
+``[-l(l+1)]^n R^{-2n}`` (see spectral [Laplacian](@ref)). It is therefore computationally not more
+expensive to apply hyperdiffusion over diffusion as the ``[-l(l+1)]^n R^{-2n}`` can be precomputed.
 Note the sign change ``(-1)^{n+1}`` here is such that the dissipative nature of the diffusion operator
 is retained for ``n`` odd and even.
 
@@ -109,7 +109,7 @@ with ``d\zeta`` being some tendency evaluated from ``\zeta_i``. Now we want to a
 with coefficient ``\nu``, which however, is implicitly calculated from ``\zeta_{i+1}``, then
 
 ```math
-\zeta_{i+1} = \zeta_{i-1} + 2\Delta t (d\zeta + (-1)^{n+1} \nu\nabla^{2n}\zeta_{i+1})
+\zeta_{i+1} = \zeta_{i-1} + 2\Delta t [d\zeta + (-1)^{n+1} \nu\nabla^{2n}\zeta_{i+1}
 ```
 As the application of ``(-1)^{n+1}\nu\nabla^{2n}`` is, for every spectral mode, equivalent to a multiplication of
 a constant, we can rewrite this to
@@ -129,7 +129,7 @@ which only depends on ``\zeta_{i-1}``. Now let ``D_\text{explicit} = (-1)^{n+1}\
 ``D_\text{implicit} = 1 - 2\Delta t \nu\nabla^{2n}`` the implicit part. Both parts can be precomputed and are
 only an element-wise multiplication in spectral space. For every spectral harmonic ``l, m`` we do
 ```math
-d\zeta \to D_\text{implicit}^{-1}(d\zeta + D_\text{explicit}\zeta_{i-1}).
+d\zeta \to D_\text{implicit}^{-1}[d\zeta + D_\text{explicit}\zeta_{i-1}].
 ```
 Hence 2 multiplications and 1 subtraction with precomputed constants.
 However, we will normalize the (hyper-)Laplacians as described in the following. This also will take care of
@@ -148,13 +148,13 @@ all entries in the discrete spectral Laplace operator are in ``[0, 1]``. This al
 alternating sign drops out, such that higher wavenumbers are always dampened and not amplified.
 The normalized coefficient ``\nu^* = l_\text{max}(l_\text{max}+1)\nu`` (always positive) is
 therefore reinterpreted as the (inverse) time scale at which the highest wavenumber is dampened
-to zero due to diffusion. Together we have 
+to zero due to diffusion. Together we have
 ```math
 D^\text{explicit}_{l, m} = -\nu^* \frac{l(l+1)}{l_\text{max}(l_\text{max}+1)}
 ```
 and the hyper-Laplacian of power ``n`` follows as
 ```math
-D^\text{explicit, n}_{l, m} = -\nu^* \left(\frac{l(l+1)}{l_\text{max}(l_\text{max}+1)}\right)^n
+D^\text{explicit, n}_{l, m} = -\nu^* \left[\frac{l(l+1)}{l_\text{max}(l_\text{max}+1)}\right]^n
 ```
 and the implicit part is accordingly ``D^\text{implicit, n}_{l, m} = 1 - 2\Delta t D^\text{explicit, n}_{l, m}``.
 Note that the diffusion time scale ``\nu^*`` is then also scaled by the radius, see next section.
@@ -177,7 +177,7 @@ The inversion of the Laplacians in order to obtain ``\Psi`` from ``\zeta`` there
 where the dimensionless gradients simply omit the scaling with ``1/R``, ``\tilde{\nabla} = R\nabla``.
 The [Barotropic vorticity equation](@ref) scaled with ``R^2`` is
 ```math
-\partial_{\tilde{t}}\tilde{\zeta} + \tilde{\nabla} \cdot (\mathbf{u}(\tilde{\zeta} + \tilde{f})) =
+\partial_{\tilde{t}}\tilde{\zeta} + \tilde{\nabla} \cdot [\mathbf{u}(\tilde{\zeta} + \tilde{f})] =
 \nabla \times \tilde{\mathbf{F}} + (-1)^{n+1}\tilde{\nu}\tilde{\nabla}^{2n}\tilde{\zeta}
 ```
 with

--- a/docs/src/convection.md
+++ b/docs/src/convection.md
@@ -29,8 +29,8 @@ which are described in the following.
 
 We follow the simplification of the Betts-Miller convection scheme
 [^Betts1986][^BettsMiller1986] as studied by Frierson, 2007 [^Frierson2007].
-The central idea of this scheme is to represent the effect of 
-convection as an adjustment towards a (pseudo-) moist adiabat 
+The central idea of this scheme is to represent the effect of
+convection as an adjustment towards a (pseudo-) moist adiabat
 reference profile and its associated humidity profile. Meaning that
 conceptually for every vertical column in the atmosphere we
 
@@ -63,7 +63,7 @@ with gravity ``g``, heat capacity ``c_p``, the saturation specific humidity of t
 (which is its specific humidity given that it has already reached saturation),
 latent heat of vaporization ``L_v``, dry gas constant ``R_d``, water vapor
 gas constant ``R_v``, and [Virtual temperature](@ref) ``T_v``.
-Starting with a temperature ``T`` and humidity ``q = q^\star`` at the lifting condensation level 
+Starting with a temperature ``T`` and humidity ``q = q^\star`` at the lifting condensation level
 temperature aloft changes with $dT = -\frac{d\Phi}{c_p}(...)$ between two layers separated
 ``d\Phi`` in geopotential ``\Phi`` apart. On that new layer, ``q^\star`` is recalculated
 as well as the virtual temperature ``T_v = T(1 + \mu q^\star)``. ``\mu`` is derived from
@@ -107,7 +107,7 @@ the resulting tendencies from this scheme. Those will be calculated in [Correcte
 
 Note that above the level of zero buoyancy no relaxation takes place ``\delta T = \delta q = 0``,
 or, equivalently ``T = T_{ref}``, ``q = q_{ref}`` there.
-Vertically integration from surface ``p_0`` to level of zero buoyancy in 
+Vertically integration from surface ``p_0`` to level of zero buoyancy in
 pressure coordinates ``p_{LZB}`` yields
 
 ```math
@@ -175,7 +175,7 @@ T_{ref,2} &= T_{ref} - \Delta T
 \end{aligned}
 ```
 
-This scheme is non-precipitating (``P_q = 0``) as derived below. ``P_q`` follows from the vertical integral of the moisture tendency ``\delta q``, which in this scheme is a relaxation towards ``q_{\text{ref,2}}`` (see [Corrected relaxation](@ref)). 
+This scheme is non-precipitating (``P_q = 0``) as derived below. ``P_q`` follows from the vertical integral of the moisture tendency ``\delta q``, which in this scheme is a relaxation towards ``q_{\text{ref,2}}`` (see [Corrected relaxation](@ref)).
 
 ```math
 P_q = -\int_{p_0}^{p_{LZB}} \frac{\delta q}{g} \, dp = \int_{p_0}^{p_{LZB}} \frac{q - q_{\text{ref,2}}}{g \tau_{SBM}} dp
@@ -187,7 +187,7 @@ Inserting from above yields
 P_q = \int_{p_0}^{p_{LZB}} \frac{q - \left(1 - \frac{\Delta q}{Q_{\text{ref}}} \right) q_{\text{ref}} }{g \tau_{SBM}} dp = \frac{1}{g \tau_{SBM}} \int_{p_0}^{p_{LZB}} \left( q - q_{\text{ref}} + \frac{\Delta q}{Q_{\text{ref}}} q_{\text{ref}} \right) dp
 ```
 
-The integral becomes 
+The integral becomes
 ```math
 \Delta q + \frac{\Delta q}{Q_{\text{ref}}} \int_{p_0}^{p_{LZB}}q_{\text{ref}} dp = \Delta q + \frac{\Delta q}{Q_{\text{ref}}} (- Q_{\text{ref}}) = 0
 ```

--- a/docs/src/convection.md
+++ b/docs/src/convection.md
@@ -130,8 +130,8 @@ through condensation, but ``P_q`` can also be negative. Consequently similar for
 We now distinguish three cases
 
 1. Deep convection when ``P_T > 0`` and ``P_q > 0``
-2. Shallow convection when ``P_T > 0`` and ``P_q <= 0``
-3. No convection for ``P_T <= 0``.
+2. Shallow convection when ``P_T > 0`` and ``P_q \le 0``
+3. No convection for ``P_T \le 0``.
 
 Note that to evaluate these cases it is not necessary to divide by ``\tau_{SBM}`` in
 the first-guess relaxation, neither are the ``1/g`` and ``\tfrac{c_p}{g L_v}``

--- a/docs/src/convection.md
+++ b/docs/src/convection.md
@@ -43,7 +43,7 @@ conceptually for every vertical column in the atmosphere we
 The dry adiabat is
 
 ```math
-T = T_0 (\frac{p}{p_0})^\frac{R}{c_p}
+T = T_0 \left(\frac{p}{p_0}\right)^\frac{R}{c_p}
 ```
 
 The temperature ``T`` of an air parcel at pressure ``p`` is determined by the
@@ -54,9 +54,9 @@ The pseudo adiabat follows the dry adiabat until saturation is reached
 Then it follows the pseudoadiabatic lapse rate
 
 ```math
-\Gamma = -\frac{dT}{dz} = \frac{g}{c_p}\left(
+\Gamma = -\frac{dT}{dz} = \frac{g}{c_p}\left[
     \frac{  1 + \frac{q^\star L_v  }{(1-q^\star)^2     R_d T_v}}{
-            1 + \frac{q^\star L_v^2}{(1-q^\star)^2 c_p R_v T^2}}\right)
+            1 + \frac{q^\star L_v^2}{(1-q^\star)^2 c_p R_v T^2}}\right]
 ```
 
 with gravity ``g``, heat capacity ``c_p``, the saturation specific humidity of the parcel ``q^\star``
@@ -148,7 +148,7 @@ Following Frierson, 2007 [^Frierson2007] in order to conserve enthalpy we correc
 the reference profile for temperature ``T_{ref} \to T_{ref, 2}`` so that ``P_T = P_q``.
 
 ```math
-T_{ref, 2} = T_{ref} + \frac{1}{\Delta p c_p} \int_{p_0}^{p_{LZB}} c_p (T - T_{ref}) + L_v (q - q_{ref}) dp
+T_{ref, 2} = T_{ref} + \frac{1}{\Delta p c_p} \int_{p_0}^{p_{LZB}} \left[ c_p (T - T_{ref}) + L_v (q - q_{ref}) \right] dp
 ```
 
 ``\Delta p`` is the pressure difference ``p_{LZB} - p_0``.
@@ -166,11 +166,11 @@ determined during the calculation of the [Reference profiles](@ref).
 
 ```math
 \begin{aligned}
-\Delta q &= \int_{p_0}^{p_{LZB}} q - q_{ref} dp \\
-Q_{ref}  &= \int_{p_0}^{p_{LZB}} -q_{ref} dp \\
-f_q      &= 1 - \frac{\Delta q}{Q_ref} \\
+\Delta q &= \int_{p_0}^{p_{LZB}} (q - q_{ref}) dp \\
+Q_{ref}  &= \int_{p_0}^{p_{LZB}} -q_{ref}~dp \\
+f_q      &= 1 - \frac{\Delta q}{Q_{ref}} \\
 q_{ref, 2} &= f_q q_{ref} \\
-\Delta T &= \frac{1}{\Delta p} \int_{p_0}^{p_{LZB}} -(T - T_{ref}) dp \\
+\Delta T &= -\frac{1}{\Delta p} \int_{p_0}^{p_{LZB}} (T - T_{ref}) dp \\
 T_{ref,2} &= T_{ref} - \Delta T
 \end{aligned}
 ```

--- a/docs/src/forcing_drag.md
+++ b/docs/src/forcing_drag.md
@@ -7,9 +7,9 @@ as defined in [Vallis et al., 2004](https://doi.org/10.1175/1520-0469(2004)061%3
 
 ```math
 \begin{aligned}
-\frac{\partial \zeta}{\partial t} &+ \nabla \cdot (\mathbf{u}(\zeta + f)) =
+\frac{\partial \zeta}{\partial t} &+ \nabla \cdot [\mathbf{u}(\zeta + f)] =
 S - r\zeta - \nu\nabla^{4}\zeta \\
-S_{l, m}^i &= A(1-\exp(-2\tfrac{\Delta t}{\tau}))Q^i_{l, m} + \exp(-\tfrac{\Delta t}{\tau})S_{l, m}^{i-1} \\
+S_{l, m}^i &= A\left[1-\exp\left(-2\tfrac{\Delta t}{\tau}\right)\right]Q^i_{l, m} + \exp\left(-\tfrac{\Delta t}{\tau}\right)S_{l, m}^{i-1} \\
 \end{aligned}
 ```
 
@@ -81,7 +81,7 @@ field, which does not have a default but will be initialised with the help of a 
 as explained later. So once we call `StochasticStirring{NF}(trunc=31)` then `S` will automatically
 have the right size.
 
-Then we also see in the definition of `S` that there are prefactors ``A(1-\exp(-2\tfrac{\Delta t}{\tau}))``
+Then we also see in the definition of `S` that there are prefactors ``A[1-\exp(-2\tfrac{\Delta t}{\tau})]``
 which depend on the forcing's parameters but also on the time step, which, at the time of the creation
 of `StochasticStirring` we might not know about! And definitely do not want to hardcode in.
 So to illustrate what you can do in this case we define two additional parameters `a, b` that
@@ -101,7 +101,7 @@ zero. For this we want to define a latitudinal mask `lat_mask` that is a vector 
 the number of latitude rings. Similar to `S`, we want to allocate it with zeros (or any other
 value for that matter), but then precompute this mask in the `initialize!` step. For this
 we need to know `nlat` at creation time meaning we add this field similar as to how we added
-`trunc`. This mask requires the parameters `latitude` (it's position) and a `width` which
+`trunc`. This mask requires the parameters `latitude` (its position) and a `width` which
 are therefore also added to the definition of `StochasticStirring`.
 
 ## Custom forcing: generator function

--- a/docs/src/gradients.md
+++ b/docs/src/gradients.md
@@ -36,9 +36,9 @@ expect the input velocity fields to be scaled by ``\cos^{-1}(\theta)``, i.e.
 
 ```math
 \begin{aligned}
-\hat{\nabla} \cdot (\cos^{-1}(\theta)\mathbf{u}) &= \frac{\partial u}{\partial \lambda} +
+\hat{\nabla} \cdot [\cos^{-1}(\theta)\mathbf{u}] &= \frac{\partial u}{\partial \lambda} +
 \cos\theta\frac{\partial v}{\partial \theta} = R\nabla \cdot \mathbf{u}, \\
-\hat{\nabla} \times (\cos^{-1}(\theta)\mathbf{u}) &= \frac{\partial v}{\partial \lambda} -
+\hat{\nabla} \times [\cos^{-1}(\theta)\mathbf{u}] &= \frac{\partial v}{\partial \lambda} -
 \cos\theta\frac{\partial u}{\partial \theta} = R\nabla \times \mathbf{u}.
 \end{aligned}
 ```

--- a/docs/src/large_scale_condensation.md
+++ b/docs/src/large_scale_condensation.md
@@ -39,7 +39,7 @@ humidity calculated from temperature ``T_i`` is
 ```math
 \begin{aligned}
 q_{i+1} - q_i &= q^\star(T_i) - q_i \\
-T_{i+1} - T_i &= -\frac{L_v}{c_p}( q^\star(T_i) - q_i  )
+T_{i+1} - T_i &= -\frac{L_v}{c_p}[ q^\star(T_i) - q_i ]
 \end{aligned}
 ```
 
@@ -66,7 +66,7 @@ Now we make a linear approximation to the derivative and drop the ``O(\Delta T^2
 Inserting the (explicit) latent heat release yields
 
 ```math
-\Delta q = q^\star(T_i) + -\frac{L_v}{c_p} \Delta q \frac{\partial q^\star}{\partial T} (T_i) - q_i
+\Delta q = q^\star(T_i) - \frac{L_v}{c_p} \Delta q \frac{\partial q^\star}{\partial T} (T_i) - q_i
 ```
 
 And solving for ``\Delta q`` yields
@@ -93,7 +93,7 @@ anymore but over several time steps ``\Delta t`` of the leapfrogging.
 ```math
 \begin{aligned}
 \delta q = \frac{q_{i+1} - q_i}{\Delta t} &= \frac{q^\star(T_i) - q_i}{ \Delta t_c
-\left( 1 + \frac{L_v}{c_p} \frac{\partial q^\star}{\partial T}(T_i) \right)} \\
+\left[ 1 + \frac{L_v}{c_p} \frac{\partial q^\star}{\partial T}(T_i) \right]} \\
 \delta T = \frac{T_{i+1} - T_i}{\Delta t} &= -\frac{L_v}{c_p}( \frac{q_{i+1} - q_i}{\Delta t} )
 \end{aligned}
 ```
@@ -118,7 +118,7 @@ as follows
 
 ```math
 \delta q = \frac{q_{i+1} - q_i}{\Delta t} = \frac{rq^\star(T_i) - q_i}{ \Delta t_c
-\left( 1 + \frac{L_vr}{c_p} \frac{\partial q^\star}{\partial T}(T_i) \right)}
+\left[ 1 + \frac{L_vr}{c_p} \frac{\partial q^\star}{\partial T}(T_i) \right]}
 ```
 ``r`` is a linear scale and therefore can be taken out of the gradient
 ``\frac{\partial q^\star}{\partial T}`` in the denominator.
@@ -160,7 +160,7 @@ implicit time stepping can be used as before if reevaporation is calculated befo
 latent heat release.
 
 The reevaportation in `ImplicitCondensation` is controlled by `reevaporation` (dimensionless),
-the proportionality constant ``c \geq 0`` here. 
+the proportionality constant ``c \geq 0`` here.
 
 ```@example condensation
 spectral_grid = SpectralGrid()
@@ -212,7 +212,7 @@ F_m = \min(F_s, \frac{E_m}{L_i}\frac{\Delta p}{\Delta t g\rho})
 
 We cap this to ``F_s`` so that one cannot melt more snow than there is. This snow melt flux
 is then subtracted from ``F_s`` but added to ``F_r`` to move snow water to rain water.
-The according latent heat required for melting is 
+The according latent heat required for melting is
 
 ```math
 \begin{aligned}
@@ -246,7 +246,7 @@ integrated (top to bottom, the direction of pressure ``p``) to diagnose the
 large-scale precipitation ``P`` in units of meters
 
 ```math
-P = - \int_{top}^{bottom} \frac{\Delta t}{g \rho} \delta q dp 
+P = - \int_{top}^{bottom} \frac{\Delta t}{g \rho} \delta q dp
 ```
 
 with gravity ``g``, water density ``\rho`` and time step ``\Delta t``.

--- a/docs/src/large_scale_condensation.md
+++ b/docs/src/large_scale_condensation.md
@@ -207,7 +207,7 @@ in meters per second what we also use for the snow and rain water fluxes ``F_r, 
 the actual snow height as it would have on the ground but if melted to water.
 
 ```math
-F_m = \min(F_s, \frac{E_m}{L_i}\frac{\Delta p}{\Delta t g\rho})
+F_m = \min\left(F_s, \frac{E_m}{L_i}\frac{\Delta p}{\Delta t g\rho}\right)
 ```
 
 We cap this to ``F_s`` so that one cannot melt more snow than there is. This snow melt flux

--- a/docs/src/particles.md
+++ b/docs/src/particles.md
@@ -48,8 +48,8 @@ velocity at departure time ``i`` and location ``\mathbf{x}_i`` and at a
 ```math
 \begin{aligned}
 \mathbf{x}^\star_{i+1} &= \mathbf{x}_i + \Delta t~\mathbf{u}_i (\mathbf{x}_i) \\
-\mathbf{x}_{i+1} &= \mathbf{x}_i + \frac{\Delta t}{2}~\left(
-    \mathbf{u}_i (\mathbf{x}_i) + \mathbf{u}_{i+1} (\mathbf{x}^\star_{i+1})\right)
+\mathbf{x}_{i+1} &= \mathbf{x}_i + \frac{\Delta t}{2} \left[
+    \mathbf{u}_i (\mathbf{x}_i) + \mathbf{u}_{i+1} (\mathbf{x}^\star_{i+1})\right]
 \end{aligned}
 ```
 
@@ -69,8 +69,8 @@ on the time step that goes from ``i-1`` to ``i``.
 ```math
 \begin{aligned}
 \mathbf{x}^\star_{i+1} &= \mathbf{x}_i + \Delta t~\mathbf{u}_i (\mathbf{x}_i) \\
-\mathbf{x}_{i+1} &= \mathbf{x}_i + \frac{\Delta t}{2}~\left(
-    \mathbf{u}_i (\mathbf{x}_i) + \mathbf{u}_{i+1} [\mathbf{x}^\star_{i+1}]\right) \\
+\mathbf{x}_{i+1} &= \mathbf{x}_i + \frac{\Delta t}{2} \left[
+    \mathbf{u}_i (\mathbf{x}_i) + \mathbf{u}_{i+1} [\mathbf{x}^\star_{i+1}]\right] \\
 \mathbf{u}_{i+1} (\mathbf{x}_{i+1}) &=  \mathbf{u}_{i+1} [\mathbf{x}_{i+1}]
 \end{aligned}
 ```

--- a/docs/src/primitiveequation.md
+++ b/docs/src/primitiveequation.md
@@ -82,8 +82,8 @@ the ideal gas law as total density ``\rho`` times a gas constant
 times the virtual temperature that is supposed to be a function
 of absolute temperature, humidity and some constants
 ```math
-p  = \left[\rho R_d + \rho_w (R_w - R_d)\right] T = \rho R_d (1 +
-\frac{1 - \tfrac{R_d}{R_w}}{\tfrac{R_d}{R_w}} \frac{\rho_w}{\rho_w + \rho_d})T
+p  = \left[\rho R_d + \rho_w (R_w - R_d)\right] T = \rho R_d \left[1 +
+\frac{1 - \tfrac{R_d}{R_w}}{\tfrac{R_d}{R_w}} \frac{\rho_w}{\rho_w + \rho_d}\right]T
 ```
 Now we identify
 ```math
@@ -309,7 +309,7 @@ The advection equation ``\tfrac{DT}{Dt} = 0`` for a tracer ``T`` is, in flux for
 for layer ``k``:
 ```math
 \frac{\partial (T_k \Delta p_k)}{\partial t} = - \nabla \cdot (\mathbf{u}_k T_k \Delta p_k)
-- (M_{k+\tfrac{1}{2}}T_{k+\tfrac{1}{2}} - M_{k-\tfrac{1}{2}}T_{k-\tfrac{1}{2}})
+- \left(M_{k+\tfrac{1}{2}}T_{k+\tfrac{1}{2}} - M_{k-\tfrac{1}{2}}T_{k-\tfrac{1}{2}}\right)
 ```
 
 Starting from this equation in pressure layer $k$, we can derive the advective form of the tracer transport. Dividing through by the layer thickness ``\Delta p_k`` gives:
@@ -348,14 +348,14 @@ Rearranging terms, we obtain:
 
 ```math
 \frac{\partial T_k}{\partial t} = - \mathbf{u}_k \cdot \nabla T_k
-- \frac{1}{\Delta \sigma_k}\left(\dot{\sigma}_{k+\tfrac{1}{2}}(T_{k+\tfrac{1}{2}} - T_k) + \dot{\sigma}_{k-\tfrac{1}{2}}(T_k - T_{k-\tfrac{1}{2}})\right)
+- \frac{1}{\Delta \sigma_k}\left[\dot{\sigma}_{k+\tfrac{1}{2}}(T_{k+\tfrac{1}{2}} - T_k) + \dot{\sigma}_{k-\tfrac{1}{2}}(T_k - T_{k-\tfrac{1}{2}})\right]
 ```
 
 With the reconstruction at the faces, ``T_{k+\tfrac{1}{2}}`` and ``T_{k-\tfrac{1}{2}}`` depending on one's choice of the advection scheme. For a second-order centered scheme, we choose ``T_{k+\tfrac{1}{2}} = \tfrac{1}{2}(T_k + T_{k+1})`` and obtain:
 
 ```math
 \frac{\partial T_k}{\partial t} = - \mathbf{u}_k \cdot \nabla T_k
-- \frac{1}{2\Delta \sigma_k}\left(\dot{\sigma}_{k+\tfrac{1}{2}}(T_{k+1} - T_k) + \dot{\sigma}_{k-\tfrac{1}{2}}(T_k - T_{k-1})\right)
+- \frac{1}{2\Delta \sigma_k}\left[\dot{\sigma}_{k+\tfrac{1}{2}}(T_{k+1} - T_k) + \dot{\sigma}_{k-\tfrac{1}{2}}(T_k - T_{k-1})\right]
 ```
 
 However, note that this scheme is dispersive and easily leads to instabilities at higher resolution, where a more advanced vertical advection scheme becomes necessary. For convenience, we may write ``W(T)`` to denote the vertical advection term ``\dot{\sigma}\partial_\sigma T``, without specifying which schemes is used.
@@ -368,7 +368,7 @@ Similarly, the conservation of mass for layer ``k`` can be expressed as
 (setting ``T=1`` in the advection equation in section [Vertical advection](@ref))
 ```math
 \frac{\partial \Delta p_k}{\partial t} = -\nabla \cdot (\mathbf{u}_k \Delta p_k)
-- (M_{k+\tfrac{1}{2}} - M_{k-\tfrac{1}{2}})
+- \left(M_{k+\tfrac{1}{2}} - M_{k-\tfrac{1}{2}}\right)
 ```
 Meaning that the pressure thickness ``\Delta p_k`` of layer ``k`` changes with
 a horizontal divergence ``-\nabla \cdot (\mathbf{u}_k \Delta p_k)`` if not
@@ -679,7 +679,7 @@ So what is ``G`` in the [Primitive equation model](@ref primitive_equation_model
 
 ```math
 \begin{aligned}
-G_\mathcal{D} &= N^E_\mathcal{D} - \nabla^2(\Phi^{i-1} + R_dT_k^v (\ln p_s)^{i-1})
+G_\mathcal{D} &= N^E_\mathcal{D} - \nabla^2[\Phi^{i-1} + R_dT_k^v (\ln p_s)^{i-1}]
 = N^E_\mathcal{D} - \nabla^2( \mathbf{R}T^{i-1} + \mathbf{U}\ln p_s^{i-1}) \\
 G_{\ln p_s} &= N_{\ln p_s}^E - \overline{\mathcal{D}^{i-1}}
 = N_{\ln p_s}^E + \mathbf{W}\mathcal{D}^{i-1} \\

--- a/docs/src/primitiveequation.md
+++ b/docs/src/primitiveequation.md
@@ -82,8 +82,8 @@ the ideal gas law as total density ``\rho`` times a gas constant
 times the virtual temperature that is supposed to be a function
 of absolute temperature, humidity and some constants
 ```math
-p  = \left[\rho R_d + \rho_w (R_w - R_d)\right] T = \rho R_d \left[1 +
-\frac{1 - \tfrac{R_d}{R_w}}{\tfrac{R_d}{R_w}} \frac{\rho_w}{\rho_w + \rho_d}\right]T
+p  = \left[\rho R_d + \rho_w (R_w - R_d)\right] T = \rho R_d \left(1 +
+\frac{1 - \tfrac{R_d}{R_w}}{\tfrac{R_d}{R_w}} \frac{\rho_w}{\rho_w + \rho_d}\right)T
 ```
 Now we identify
 ```math
@@ -182,7 +182,7 @@ p_k = \sigma_kp_s
 The layer thickness in terms of pressure is
 ```math
 \Delta p_k = p_{k+\tfrac{1}{2}} - p_{k-\tfrac{1}{2}} =
-(\sigma_{k+\tfrac{1}{2}} - \sigma_{k-\tfrac{1}{2}}) p_s = \Delta \sigma_k p_s
+\left( \sigma_{k+\tfrac{1}{2}} - \sigma_{k-\tfrac{1}{2}} \right) p_s = \Delta \sigma_k p_s
 ```
 which can also be expressed with the layer thickness in sigma coordinates ``\Delta \sigma_k``
 times the surface pressure. In SpeedyWeather.jl one chooses the half levels
@@ -348,7 +348,7 @@ Rearranging terms, we obtain:
 
 ```math
 \frac{\partial T_k}{\partial t} = - \mathbf{u}_k \cdot \nabla T_k
-- \frac{1}{\Delta \sigma_k}\left[\dot{\sigma}_{k+\tfrac{1}{2}}(T_{k+\tfrac{1}{2}} - T_k) + \dot{\sigma}_{k-\tfrac{1}{2}}(T_k - T_{k-\tfrac{1}{2}})\right]
+- \frac{1}{\Delta \sigma_k}\left[\dot{\sigma}_{k+\tfrac{1}{2}}\left(T_{k+\tfrac{1}{2}} - T_k\right) + \dot{\sigma}_{k-\tfrac{1}{2}}\left(T_k - T_{k-\tfrac{1}{2}}\right)\right]
 ```
 
 With the reconstruction at the faces, ``T_{k+\tfrac{1}{2}}`` and ``T_{k-\tfrac{1}{2}}`` depending on one's choice of the advection scheme. For a second-order centered scheme, we choose ``T_{k+\tfrac{1}{2}} = \tfrac{1}{2}(T_k + T_{k+1})`` and obtain:
@@ -457,7 +457,7 @@ In vorticity-divergence formulation of the momentum equations the ``\nabla_\sigm
 drops out in the vorticity equation (``\nabla \times \nabla \Phi = 0``),
 but becomes a ``-\nabla^2 \Phi`` in the divergence equation,
 which is therefore combined with the kinetic energy term
-``-\nabla^2(\tfrac{1}{2}(u^2 + v^2))`` similar as it is done in the [Shallow water equations](@ref).
+``-\nabla^2[\tfrac{1}{2}(u^2 + v^2)]`` similar as it is done in the [Shallow water equations](@ref).
 You can think of ``\tfrac{1}{2}(u^2 + v^2) + \Phi`` as the Bernoulli potential in
 the primitive equations. However, due to the change into sigma coordinates the surface pressure
 gradient also has to be accounted for. Now highlighting only the pressure gradient force, we

--- a/docs/src/primitiveequation.md
+++ b/docs/src/primitiveequation.md
@@ -9,10 +9,10 @@ logarithm of surface pressure ``\ln p_s``, temperature ``T`` and specific humidi
 
 ```math
 \begin{aligned}
-\frac{\partial \zeta}{\partial t} &= \nabla \times (\mathbf{\mathcal{P}}_\mathbf{u}
-+ (f+\zeta)\mathbf{u}_\perp - W(\mathbf{u}) - R_dT_v\nabla \ln p_s) \\
-\frac{\partial \mathcal{D}}{\partial t} &= \nabla \cdot (\mathcal{P}_\mathbf{u}
-+ (f+\zeta)\mathbf{u}_\perp - W(\mathbf{u}) - R_dT_v\nabla \ln p_s) - \nabla^2(\frac{1}{2}(u^2 + v^2) + \Phi) \\
+\frac{\partial \zeta}{\partial t} &= \nabla \times \left[\mathbf{\mathcal{P}}_\mathbf{u}
++ (f+\zeta)\mathbf{u}_\perp - W(\mathbf{u}) - R_dT_v\nabla \ln p_s\right] \\
+\frac{\partial \mathcal{D}}{\partial t} &= \nabla \cdot \left[\mathcal{P}_\mathbf{u}
++ (f+\zeta)\mathbf{u}_\perp - W(\mathbf{u}) - R_dT_v\nabla \ln p_s\right] - \nabla^2\left[\tfrac{1}{2}(u^2 + v^2) + \Phi\right] \\
 \frac{\partial \ln p_s}{\partial t} &= -\frac{1}{p_s} \nabla \cdot \int_0^{p_s} \mathbf{u}~dp \\
 \frac{\partial T}{\partial t} &= \mathcal{P}_T -\nabla\cdot(\mathbf{u}T) + T\mathcal{D} - W(T) + \kappa T_v \frac{D \ln p}{Dt} \\
 \frac{\partial q}{\partial t} &= \mathcal{P}_q -\nabla\cdot(\mathbf{u}q) + q\mathcal{D} - W(q)\\
@@ -25,12 +25,12 @@ Coriolis parameter ``f``, ``W`` the [Vertical advection](@ref) operator, dry air
 and surface pressure ``p_s``, thermodynamic ``\kappa = R_d/c_p``
 with ``c_p`` the heat capacity at constant pressure. Horizontal hyper diffusion of the
 form ``(-1)^{n+1}\nu\nabla^{2n}`` with coefficient ``\nu`` and power ``n``  is added for
-every variable that is advected, meaning ``\zeta, \mathcal{D}, T, q``, but left out
+every variable that is advected, meaning ``\zeta``, ``\mathcal{D}``, ``T``, ``q``, but left out
 here for clarity, see [Horizontal diffusion](@ref diffusion).
 
-The parameterizations for the tendencies of ``u, v, T, q`` from physical processes are denoted as
-``\mathcal{P}_\mathbf{u} = (\mathcal{P}_u, \mathcal{P}_v), \mathcal{P}_T, \mathcal{P}_q``
-and are further described in the corresponding sections, see [Parameterizations](@ref).
+The parameterizations for the tendencies of ``u``, ``v``, ``T``, ``q`` from physical processes are
+denoted as ``\mathcal{P}_\mathbf{u} = (\mathcal{P}_u, \mathcal{P}_v)``, ``\mathcal{P}_T``, ``\mathcal{P}_q``
+respectively and are further described in the corresponding sections, see [Parameterizations](@ref).
 
 SpeedyWeather.jl implements a `PrimitiveWet` and a `PrimitiveDry` dynamical core.
 For a dry atmosphere, we have ``q = 0`` and the virtual temperature ``T_v = T``
@@ -82,7 +82,7 @@ the ideal gas law as total density ``\rho`` times a gas constant
 times the virtual temperature that is supposed to be a function
 of absolute temperature, humidity and some constants
 ```math
-p  = (\rho R_d + \rho_w (R_w - R_d)) T = \rho R_d (1 +
+p  = \left[\rho R_d + \rho_w (R_w - R_d)\right] T = \rho R_d (1 +
 \frac{1 - \tfrac{R_d}{R_w}}{\tfrac{R_d}{R_w}} \frac{\rho_w}{\rho_w + \rho_d})T
 ```
 Now we identify

--- a/docs/src/primitiveequation.md
+++ b/docs/src/primitiveequation.md
@@ -28,7 +28,7 @@ form ``(-1)^{n+1}\nu\nabla^{2n}`` with coefficient ``\nu`` and power ``n``  is a
 every variable that is advected, meaning ``\zeta``, ``\mathcal{D}``, ``T``, ``q``, but left out
 here for clarity, see [Horizontal diffusion](@ref diffusion).
 
-The parameterizations for the tendencies of ``u``, ``v``, ``T``, ``q`` from physical processes are
+The parameterizations for the tendencies of ``\mathbf{u}=(u, v)``, ``T``, ``q`` from physical processes are
 denoted as ``\mathcal{P}_\mathbf{u} = (\mathcal{P}_u, \mathcal{P}_v)``, ``\mathcal{P}_T``, ``\mathcal{P}_q``
 respectively and are further described in the corresponding sections, see [Parameterizations](@ref).
 
@@ -751,7 +751,7 @@ via
 ```
 (``\mathbf{UW}`` is a matrix of size ``N \times N``) yields
 ```math
-\delta D = \left( 1 + \xi^2\nabla^2(\mathbf{RL + UW})  \right)^{-1}G = \mathbf{S}^{-1}G
+\delta D = \left[ 1 + \xi^2\nabla^2(\mathbf{RL + UW}) \right]^{-1}G = \mathbf{S}^{-1}G
 ```
 The other tendencies ``\delta T`` and ``\delta \ln p_s`` are then obtained
 through insertion above. We may call the operator to be inverted ``\mathbf{S}``

--- a/docs/src/shallowwater.md
+++ b/docs/src/shallowwater.md
@@ -238,11 +238,11 @@ a single divergence/curl operation as mentioned in [Shallow water equations](@re
 ```math
 \begin{aligned}
 \frac{\partial \tilde{\zeta}}{\partial \tilde{t}} &=
-\tilde{\nabla} \times (\tilde{\mathbf{F}} + \mathbf{u}_\perp(\tilde{\zeta} + \tilde{f})) +
+\tilde{\nabla} \times \left[\tilde{\mathbf{F}} + \mathbf{u}_\perp(\tilde{\zeta} + \tilde{f})\right] +
 (-1)^{n+1}\tilde{\nu}\tilde{\nabla}^{2n}\tilde{\zeta} \\
 \frac{\partial \tilde{\mathcal{D}}}{\partial \tilde{t}} &=
-\tilde{\nabla} \cdot (\tilde{\mathbf{F}} + \mathbf{u}_\perp(\tilde{\zeta} + \tilde{f})) -
-\tilde{\nabla}^2\left(\tfrac{1}{2}(u^2 + v^2) + g\eta \right) +
+\tilde{\nabla} \cdot \left[\tilde{\mathbf{F}} + \mathbf{u}_\perp(\tilde{\zeta} + \tilde{f})\right] -
+\tilde{\nabla}^2\left[\tfrac{1}{2}(u^2 + v^2) + g\eta \right] +
 (-1)^{n+1}\tilde{\nu}\tilde{\nabla}^{2n}\tilde{\mathcal{D}} \\
 \frac{\partial \eta}{\partial \tilde{t}} &=
 - \tilde{\nabla} \cdot (\mathbf{u}h) + \tilde{F}_\eta.

--- a/docs/src/shallowwater.md
+++ b/docs/src/shallowwater.md
@@ -18,11 +18,11 @@ divergence ``\mathcal{D} = \nabla \cdot \mathbf{u}``
 
 ```math
 \begin{aligned}
-\frac{\partial \zeta}{\partial t} + \nabla \cdot (\mathbf{u}(\zeta + f)) &=
+\frac{\partial \zeta}{\partial t} + \nabla \cdot \left[\mathbf{u}(\zeta + f)\right] &=
 F_\zeta + \nabla \times \mathbf{F}_\mathbf{u} + (-1)^{n+1}\nu\nabla^{2n}\zeta, \\
-\frac{\partial \mathcal{D}}{\partial t} - \nabla \times (\mathbf{u}(\zeta + f)) &=
+\frac{\partial \mathcal{D}}{\partial t} - \nabla \times \left[\mathbf{u}(\zeta + f)\right] &=
 F_\mathcal{D} + \nabla \cdot \mathbf{F}_\mathbf{u}
--\nabla^2(\tfrac{1}{2}(u^2 + v^2) + g\eta) + (-1)^{n+1}\nu\nabla^{2n}\mathcal{D}, \\
+-\nabla^2\left[\tfrac{1}{2}(u^2 + v^2) + g\eta\right] + (-1)^{n+1}\nu\nabla^{2n}\mathcal{D}, \\
 \frac{\partial \eta}{\partial t} + \nabla \cdot (\mathbf{u}h) &= F_\eta,
 \end{aligned}
 ```
@@ -37,8 +37,8 @@ h = \eta + H - H_b
 ```
 that is, the layer thickness at rest ``H`` plus the interface height ``\eta`` minus orography ``H_b``.
 We also add various possible forcing terms
-``F_\zeta, F_\mathcal{D}, F_\eta, \mathbf{F}_\mathbf{u} = (F_u, F_v)`` which can be defined 
-to force the respective variables, see [Extending SpeedyWeather](@ref). 
+``F_\zeta, F_\mathcal{D}, F_\eta, \mathbf{F}_\mathbf{u} = (F_u, F_v)`` which can be defined
+to force the respective variables, see [Extending SpeedyWeather](@ref).
 
 In the shallow water system the flow can be described through ``u, v`` or ``\zeta, \mathcal{D}`` which
 are related through the stream function ``\Psi`` and the velocity potential ``\Phi`` (which is zero
@@ -110,7 +110,7 @@ In spectral space ``\nabla^2`` is a diagonal operator, meaning that there is no 
 harmonics and its inversion is therefore easily done on a mode-by-mode basis of the harmonics.
 
 This can be made use of when facing time stepping constraints with explicit schemes, where
-ridiculously small time steps to resolve fast waves would otherwise result in a horribly slow simulation. 
+ridiculously small time steps to resolve fast waves would otherwise result in a horribly slow simulation.
 In the shallow water system there are gravity waves that propagate at a wave speed of ``\sqrt{gH}``
 (typically 300m/s), which, in order to not violate the
 [CFL criterion](https://en.wikipedia.org/wiki/Courant%E2%80%93Friedrichs%E2%80%93Lewy_condition)
@@ -153,7 +153,7 @@ by inverting ``N_I``, but let us gather the other terms as ``G`` first.
 ```math
 G = N_E(V_i) + N_I(V_{i-1}) = N(V_i) + N_I(V_{i-1} - V_i)
 ```
-For the shallow water equations we will only make use of the last formulation, meaning 
+For the shallow water equations we will only make use of the last formulation, meaning
 we first evaluate the whole right-hand side ``N(V_i)`` at the current time step
 as we would do with fully explicit time stepping but then add the implicit terms
 ``N_I(V_{i-1} - V_i)`` afterwards to move those terms from ``i`` to ``i-1``.
@@ -202,7 +202,7 @@ independently, so the Laplace operator ``\nabla^2 = -l(l+1)`` takes the form of 
 ``-l(l+1)`` (normalized to unit sphere, as are the [scaled shallow water equations](@ref scaled_swm))
 and its inversion is therefore just the inversion of this scalar.
 ```math
-\delta D = \frac{G_\mathcal{D} - \xi g\nabla^2 G_\eta}{1 - \xi^2 H \nabla^2} =: S^{-1}(G_\mathcal{D} - \xi g\nabla^2 G_\eta) 
+\delta D = \frac{G_\mathcal{D} - \xi g\nabla^2 G_\eta}{1 - \xi^2 H \nabla^2} =: S^{-1}(G_\mathcal{D} - \xi g\nabla^2 G_\eta)
 ```
 Where the last formulation just makes it clear that ``S = 1 - \xi^2 H \nabla^2`` is the
 operator to be inverted. ``\delta \eta`` is then obtained via insertion as written above.
@@ -253,7 +253,7 @@ As in the [scaled barotropic vorticity equations](@ref scaling), one needs to sc
 the time step, the Coriolis force, the forcing and the diffusion coefficient, but then
 enjoys the luxury of working with dimensionless gradient operators. As before,
 SpeedyWeather.jl will scale vorticity and divergence just before the model integration
-starts and unscale them upon completion and for output. In the 
+starts and unscale them upon completion and for output. In the
 [semi-implicit time integration](@ref implicit_swm) we solve an equation that also
 has to be scaled. It is with radius squared scaling (because it is the tendency for
 the divergence equation which is also scaled with ``R^2``)

--- a/docs/src/shallowwater.md
+++ b/docs/src/shallowwater.md
@@ -37,7 +37,7 @@ h = \eta + H - H_b
 ```
 that is, the layer thickness at rest ``H`` plus the interface height ``\eta`` minus orography ``H_b``.
 We also add various possible forcing terms
-``F_\zeta, F_\mathcal{D}, F_\eta, \mathbf{F}_\mathbf{u} = (F_u, F_v)`` which can be defined
+``F_\zeta``, ``F_\mathcal{D}``, ``F_\eta``, ``\mathbf{F}_\mathbf{u} = (F_u, F_v)`` which can be defined
 to force the respective variables, see [Extending SpeedyWeather](@ref).
 
 In the shallow water system the flow can be described through ``u, v`` or ``\zeta, \mathcal{D}`` which
@@ -60,10 +60,10 @@ The divergence/curl of the vorticity flux ``\mathbf{u}(\zeta + f)`` are combined
 divergence/curl of the forcing vector ``\mathbf{F}``, as
 ```math
 \begin{aligned}
-- \nabla \cdot (\mathbf{u}(\zeta + f)) + \nabla \times \mathbf{F} &=
-\nabla \times (\mathbf{F} + \mathbf{u}_\perp(\zeta + f)) \\
-\nabla \times (\mathbf{u}(\zeta + f)) + \nabla \cdot \mathbf{F} &=
-\nabla \cdot (\mathbf{F} + \mathbf{u}_\perp(\zeta + f))
+- \nabla \cdot [\mathbf{u}(\zeta + f)] + \nabla \times \mathbf{F} &=
+\nabla \times [\mathbf{F} + \mathbf{u}_\perp(\zeta + f)] \\
+\nabla \times [\mathbf{u}(\zeta + f)] + \nabla \cdot \mathbf{F} &=
+\nabla \cdot [\mathbf{F} + \mathbf{u}_\perp(\zeta + f)]
 \end{aligned}
 ```
 equivalently to how this is done in the [Barotropic vorticity equation](@ref barotropic_vorticity_model)

--- a/docs/src/surface_fluxes.md
+++ b/docs/src/surface_fluxes.md
@@ -108,7 +108,7 @@ We use the same drag coefficient for momentum, heat and moisture fluxes.
 The bulk Richardson number at the lowermost model layer ``k = N`` of height ``z_N`` is
 
 ```math
-Ri_N = \frac{gz_N \left( \Theta_v(z_N) - \Theta_v(0) \right)}{|v(z_N)|^2 \Theta_v(0)}
+Ri_N = \frac{gz_N \left[ \Theta_v(z_N) - \Theta_v(0) \right]}{|v(z_N)|^2 \Theta_v(0)}
 ```
 
 with ``gz_N = \Phi_N`` the [Geopotential](@ref) at ``z = z_N``, ``\Theta =  c_pT_v + gz``
@@ -117,13 +117,13 @@ Then the drag coefficient ``C`` follows as
 
 ```math
 C = \begin{cases}
-        \kappa^2 \left( \log(\frac{z_N}{z_0}) \right)^{-2} \quad &\text{for} \quad Ri_N  \leq 0\\
-        \kappa^2 \left( \log(\frac{z_N}{z_0}) \right)^{-2} \left(1 - \frac{Ri_N}{Ri_c}\right)^2 \quad &\text{for} \quad 0 < Ri_N < Ri_c \\
-        0 \quad &\text{for} \quad Ri_N \geq Ri_c. \\
+        \kappa^2 \left[ \log(\frac{z_N}{z_0}) \right]^{-2} \quad &\text{for} \quad Ri_N  \leq 0\\
+        \kappa^2 \left[ \log(\frac{z_N}{z_0}) \right]^{-2} \left(1 - \frac{Ri_N}{Ri_c}\right)^2 \quad &\text{for} \quad 0 < Ri_N < Ri_c \\
+        0 \quad &\text{for} \quad Ri_N \geq Ri_c, \\
     \end{cases}
 ```
 
-with ``\kappa = 0.4`` the von Kármán constant, ``z_0`` the 
+with ``\kappa = 0.4`` the von Kármán constant, ``z_0`` the
 roughness length (we currently use different values over ocean and land).
 There is a maximum drag ``C`` for negative bulk Richardson numbers ``Ri_N``
 but the drag becomes 0 for bulk Richardson numbers being larger than a critical
@@ -138,13 +138,13 @@ every grid cell as it depends on temperature. The maximum drag coefficient
 then follows as
 
 ```math
-C_{max} = \left(\frac{\kappa}{\log(\frac{z}{z_0})} \right)^2
+C_{max} = \left[\frac{\kappa}{\log(\frac{z}{z_0})} \right]^2
 ```
 
 to simplify the drag coefficient calculation to
 
 ```math
-C = C_{max} \left(1 - \frac{Ri_N^*}{Ri_c}\right)^2
+C = C_{max} \left[1 - \frac{Ri_N^*}{Ri_c}\right]^2
 ```
 with ``Ri_N^* = \max(0, \min(Ri_N, Ri_c))`` the clamped ``Ri_N`` which
 is at least ``0`` and at most ``Ri_c``.
@@ -207,7 +207,7 @@ This assumes that a very thin layer of air just above the ocean is saturated but
 assumption is less well justified as it should be a function of the soil moisture and how much
 of that is available to evaporate given vegetation, hence we include a soil moisture availability.
 We again make the simplification that ``q_s = q_N``, i.e. specific humidity of the surface is the
-same as in the lowermost atmospheric layer above. 
+same as in the lowermost atmospheric layer above.
 
 The surface humidity flux in ``kg/s/m^2``, positive up, is then
 
@@ -270,8 +270,8 @@ For more details see [The land-sea mask](@ref) implementation section.
 
 ## References
 
-[^Frierson2006]: Frierson, D. M. W., I. M. Held, and P. Zurita-Gotor, 2006: A Gray-Radiation Aquaplanet Moist GCM. Part I: Static Stability and Eddy Scale. J. Atmos. Sci., 63, 2548-2566. DOI: [10.1175/JAS3753.1](https://doi.org/10.1175/JAS3753.1). 
+[^Frierson2006]: Frierson, D. M. W., I. M. Held, and P. Zurita-Gotor, 2006: A Gray-Radiation Aquaplanet Moist GCM. Part I: Static Stability and Eddy Scale. J. Atmos. Sci., 63, 2548-2566. DOI: [10.1175/JAS3753.1](https://doi.org/10.1175/JAS3753.1).
 
 [^SPEEDY]: Franco Molteni and Fred Kucharski, 20??. Description of the ICTP AGCM (SPEEDY) Version 41. [https://users.ictp.it/~kucharsk/speedy_description/km_ver41_appendixA.pdf](https://users.ictp.it/~kucharsk/speedy_description/km_ver41_appendixA.pdf)
 
-[^Viterbo95]: Viterbo, P., and A. C. M. Beljaars, 1995: An Improved Land Surface Parameterization Scheme in the ECMWF Model and Its Validation. J. Climate, 8, 2716-2748, DOI:[10.1175/1520-0442(1995)008<2716:AILSPS>2.0.CO;2](https://doi.org/10.1175/1520-0442(1995)008<2716:AILSPS>2.0.CO;2). 
+[^Viterbo95]: Viterbo, P., and A. C. M. Beljaars, 1995: An Improved Land Surface Parameterization Scheme in the ECMWF Model and Its Validation. J. Climate, 8, 2716-2748, DOI:[10.1175/1520-0442(1995)008<2716:AILSPS>2.0.CO;2](https://doi.org/10.1175/1520-0442(1995)008<2716:AILSPS>2.0.CO;2).

--- a/docs/src/vertical_diffusion.md
+++ b/docs/src/vertical_diffusion.md
@@ -39,7 +39,7 @@ That way the diffusion preserves the integral of the variable ``u`` from
 ``\sigma = 0`` to ``\sigma = 1``.
 
 ```math
-\frac{\partial}{\partial t} \int_0^1 u d\sigma  = \int_0^1 \frac{\partial}{\partial \sigma} K
+\frac{\partial}{\partial t} \int_0^1 u~d\sigma  = \int_0^1 \frac{\partial}{\partial \sigma} K
 \frac{\partial u}{\partial \sigma} d\sigma =
 K\frac{\partial u}{\partial \sigma} \vert_{\sigma = 1} - K\frac{\partial u}{\partial \sigma} \vert_{\sigma = 0}
 = 0
@@ -71,7 +71,7 @@ We calculate the diffusion coefficient ``K`` based on the bulk Richardson number
 [^Frierson2006] which is computed as follows
 
 ```math
-Ri = \frac{gz \left( \Theta_v(z) - \Theta_v(z_N) \right)}{|v(z)|^2 \Theta_v(z_N)}
+Ri = \frac{gz \left[ \Theta_v(z) - \Theta_v(z_N) \right]}{|v(z)|^2 \Theta_v(z_N)}
 ```
 
 (see [Bulk Richardson-based drag coefficient](@ref) in comparison).
@@ -89,7 +89,7 @@ number ``Ri``.
 ```math
 K(z) = \begin{cases}
     K_b(z) \quad &\text{for} \quad z \leq f_b h \\
-    K_b(f_b h) \frac{z}{f_b h} \left( 1 - \frac{z - f_b h}{(1 - f_b)h} \right)^2
+    K_b(f_b h) \frac{z}{f_b h} \left[ 1 - \frac{z - f_b h}{(1 - f_b)h} \right]^2
         \quad &\text{for} \quad f_b h < z \leq h \\
 \end{cases}
 ```
@@ -101,7 +101,7 @@ the second case guarantees a smooth transition in ``K`` to zero at ``z = h``.
 ```math
 Kb(z) = \begin{cases}
     \kappa u_N \sqrt{C}z \quad &\text{for} \quad Ri_N \leq 0 \\
-    \kappa u_N \sqrt{C}z \left( 1 + \frac{Ri}{Ri_c}\frac{\log(z/z_0)}{1 - Ri/Ri_c}\right)^{-1}
+    \kappa u_N \sqrt{C}z \left[ 1 + \frac{Ri}{Ri_c}\frac{\log(z/z_0)}{1 - Ri/Ri_c}\right]^{-1}
         \quad &\text{for} \quad Ri_N > 0 \\
 \end{cases}
 ```


### PR DESCRIPTION
This PR fixes some math rendering in the docs.

The only non-trivial change is that in https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1072/changes#diff-711744623cb8d3002db85edfec455266b612c1179402a67eaa18630b7764b3cf where a `+ -` is replaced with `-`.