### PR TITLE
Fix typos in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed several typos in the documentation [#1094](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1094)
 - Fixed a wrong reference in the documentation [#1092](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1092)
 - Variable system: rename function that allocates new variables from `Base.zero` to `allocate` [#1087](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1087)
 

--- a/SpeedyWeather/src/parameterizations/albedo.jl
+++ b/SpeedyWeather/src/parameterizations/albedo.jl
@@ -2,7 +2,7 @@
 Albedo structs should be defined as MyAlbedo <: AbstractAlbedo and implement the following interface:
 
 - `initialize!(albedo::MyAlbedo, model)`
-- `albedo!(ij, vars::Variables, albedo::MyAlbedo, model)`
+- `albedo!(ij, albedofield, vars::Variables, albedo::MyAlbedo, model)`
 
 `initialize!` is as for every model component but in contrast to other parameterizations albedos
 should not implement `parameterization!` but rather `albedo!`, which is called from within `parameterization!`.

--- a/docs/src/differentiability.md
+++ b/docs/src/differentiability.md
@@ -54,7 +54,7 @@ dmodel.planet.gravity
 
 ## Differentiating longer trajectories and checkpointing 
 
-In a very similar fashion as for the single timestep, we can also differentiate longer trajectories. For this, we need to use checkpointing to avoid storing all intermediate states in memory. This will also at the same time keep the compile time of the gradient still manageable. For a full example on how to do this for a sensitivity analysis, see the [sensitivity example](https://github.com/SpeedyWeather/SpeedyWeather.jl/blob/main/SpeedyWeather/test/differentiatibility/sensitivity_examples/).
+In a very similar fashion as for the single timestep, we can also differentiate longer trajectories. For this, we need to use checkpointing to avoid storing all intermediate states in memory. This will also at the same time keep the compile time of the gradient still manageable. For a full example on how to do this for a sensitivity analysis, see the [sensitivity example](https://github.com/SpeedyWeather/SpeedyWeather.jl/tree/main/SpeedyWeather/test/differentiability/sensitivity_examples/).
 
 
 ## Parameter handling

--- a/docs/src/forcing_drag.md
+++ b/docs/src/forcing_drag.md
@@ -13,8 +13,8 @@ S_{l, m}^i &= A\left[1-\exp\left(-2\tfrac{\Delta t}{\tau}\right)\right]Q^i_{l, m
 \end{aligned}
 ```
 
-So there is a term `S` that is supposed to force the vorticity equation in the
-[Barotropic vorticity model]. However, this term is also stochastically
+So there is a term ``S`` that is supposed to force the vorticity equation in the
+[Barotropic vorticity model](@ref barotropic_vorticity_model). However, this term is also stochastically
 evolving in time, meaning we have to store the previous time steps, ``i-1``,
 in spectral space, because that's where the forcing is defined: for degree
 ``l`` and order ``m`` of the spherical harmonics. ``A`` is a real amplitude.
@@ -211,18 +211,16 @@ considered read-only when applying a forcing.
 `vars.tendencies` contains the tendencies (in grid and spectral space) and
 `vars.prognostic` contains the prognostic variables in spectral space, including
 `vars.prognostic.clock.time` the current time for time-dependent forcing.
-The third argument has to be of the type of our new custom forcing, here `StochasticStirring`,
-so that multiple dispatch calls the correct method of `forcing!`. The forth argument is of type
+The second argument has to be of the type of our new custom forcing, here `StochasticStirring`,
+so that multiple dispatch calls the correct method of `forcing!`. The third argument is the leapfrog index `lf` which after the first time step will
+be `lf=2` to denote that tendencies are evaluated at the current time not at the previous time (how leapfrogging works). Unless you want to read the prognostic variables, for which
+you need to know whether to read `lf=1` or `lf=2`, you can ignore this (but need to include it as argument). The forth argument is of type
 `AbstractModel`, so that the forcing can also make use of anything inside `model`, e.g.
 `model.geometry` or `model.planet` etc. But you can be more restrictive to define a forcing only
 for the `BarotropicModel` for example, use `model::Barotropic` in that case.
 Or you could define two methods, one for `Barotropic` one for all other models with
 `AbstractModel` (not `Barotropic` as a more specific method is prioritised with multiple
-dispatch). The 5th argument is the leapfrog index `lf` which after the first time step will
-be `lf=2` to denote that tendencies are evaluated at the current time not at the previous time
-(how leapfrogging works). Unless you want to read the prognostic variables, for which
-you need to know whether to read `lf=1` or `lf=2`, you can ignore this (but need to include
-it as argument).
+dispatch). 
 
 As you can see, for now not much is actually happening inside this function,
 this is what is often called a function barrier, the only thing we do in here
@@ -293,7 +291,7 @@ For details, please see [Declare variables](@ref).
 
 Scratch arrays have an undefined state as any component is free to use
 them and write data into it. In that sense, they should be treated as
-write-before-read for example to store and intermediate result. You also
+write-before-read for example to store an intermediate result. You also
 should expect them to be overwritten momentarily once the function concludes
 and no information will remain. The only exception are situations where
 a model component implements two functions that are directly called

--- a/docs/src/parameterizations.md
+++ b/docs/src/parameterizations.md
@@ -153,7 +153,7 @@ model = PrimitiveWetModel(spectral_grid, convection=my_convection)
 nothing # hide
 ```
 The following is an overview of what the parameterization fields inside the
-model are called, the are always defined in `model.parameterizations`.
+model are called, they are always defined in `model.parameterizations`.
 See also [Models](@ref), [PrimitiveDryModel](@ref) and [PrimitiveWetModel](@ref).
 
 ```@example parameterization

--- a/docs/src/time_integration.md
+++ b/docs/src/time_integration.md
@@ -1,6 +1,6 @@
 # [Time integration](@id leapfrog)
 
-SpeedyWeather.jl is based on the [Leapfrog time integration](https://en.wikipedia.org/wiki/Leapfrog_integration]),
+SpeedyWeather.jl is based on the [Leapfrog time integration](https://en.wikipedia.org/wiki/Leapfrog_integration),
 which, for relative vorticity ``\zeta``, is
 in its simplest form
 ```math


### PR DESCRIPTION
Fixed typos from [Issue #1053](https://github.com/SpeedyWeather/SpeedyWeather.jl/issues/1053) (2.6, 2.8, 3.2, 3.3, 3.6, 3.7, 3.8) and added a missing argument to the `albedo!` function docstring.