### PR TITLE
Handle heterogeneous parameter attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Handle heterogeneous parameter attributes [#1106](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1106)
 - Coupling to the Terrarium.jl land model via an SpeedyWeatherTerrariumExt [#1090](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1090)
 - The `ShallowWaterModel` is now GPU compatible [#1104](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1104)
 - Updated citations and funding information [#1100](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1100)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Handle heterogeneous parameter attributes [#1106](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1106)
+- Handle heterogeneous parameter attributes in `ParameterEditing` [#1106](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1106)
 - Coupling to the Terrarium.jl land model via an SpeedyWeatherTerrariumExt [#1090](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1090)
 - The `ShallowWaterModel` is now GPU compatible [#1104](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1104)
 - Updated citations and funding information [#1100](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1100)

--- a/SpeedyWeather/test/parameters.jl
+++ b/SpeedyWeather/test/parameters.jl
@@ -5,21 +5,6 @@ using SpeedyWeather.SpeedyWeatherInternals.ParameterEditing: NumberParam
 
 import ModelParameters: ModelParameters, Model, Param, params, update
 
-@testset "NumberParam" begin
-    # Test basic construction and getter functions
-    p = NumberParam(42.0, bounds = RealLine(), desc = "Test parameter", unit = "m", category = "generic")
-    @test SpeedyWeather.value(p) == p.val == 42.0
-    @test bounds(p) == p.bounds == RealLine()
-    @test description(p) == p.desc == "Test parameter"
-    @test attributes(p) == (unit = "m", category = "generic")
-
-    # Test ModelParameters interface
-    @test params(p) == (p,)
-    @test Model(p)[:val] == (42.0,)
-    @test SpeedyWeather.value(update(p, (1.0,))) == 1.0
-    @test stripparams(p) == 42.0
-end
-
 @testset "parameters" begin
     # check basic function of parameters method
     @test parameters(1.0) == NumberParam(1.0)
@@ -71,67 +56,4 @@ end
     @test all(==(:planet), model_ps_zero_subset[:component])
     @test all(iszero, vec(model_ps_zero_subset))
     @test length(model_ps_zero_subset) == length(vec(model_ps).planet)
-end
-
-@testset "@parameterized" begin
-    # test single parameter, no kwdef
-    ParameterEditing.@parameterized struct TestType1{T}
-        "non parameter"
-        x::T
-        "parameter"
-        @param y::T
-    end
-    ps = parameters(TestType1(0.0, 1.0))
-    @test length(ps) == 1
-    @test vec(ps).y == 1.0
-    @test ps[:desc] == ("parameter",)
-
-    # test two parameters, no kwdef
-    ParameterEditing.@parameterized struct TestType2{TX, TY, TZ}
-        "parameter"
-        @param x::TX
-        "non-parameter"
-        y::TY
-        @param z::TZ
-    end
-    ps = parameters(TestType2(0.0, 1.0, 2.0))
-    @test length(ps) == 2
-    @test vec(ps) == ComponentVector(x = 0.0, z = 2.0)
-    @test ps[:desc] == ("parameter", "")
-
-    # test one parameter, with kwdef
-    ParameterEditing.@parameterized @kwdef struct TestType3{T}
-        "parameter"
-        @param x::T = 1.0
-        "non-parameter"
-        y::T = 2.0
-    end
-    ps = parameters(TestType3())
-    @test length(ps) == 1
-    @test vec(ps) == ComponentVector(x = 1.0)
-    @test ps[:desc] == ("parameter",)
-
-    # test multiple parameters, with kwdef
-    ParameterEditing.@parameterized @kwdef struct TestType4{T1, T2}
-        "parameter 1"
-        @param x::T1 = 1.0
-        "parameter 2"
-        @param y::T1 = 2.0
-        @param z::T2 = 3.0
-        date::DateTime = DateTime(0)
-    end
-    ps = parameters(TestType4())
-    @test length(ps) == 3
-    @test vec(ps) == ComponentVector(x = 1.0, y = 2.0, z = 3.0)
-    @test ps[:desc] == ("parameter 1", "parameter 2", "")
-
-    # test parameters for nested type
-    ParameterEditing.@parameterized @kwdef struct MyModel{T}
-        @param component::T = TestType4() (group = :group1,)
-    end
-    ps = parameters(MyModel())
-    @test length(ps) == 3
-    @test haskey(parent(ps), :component)
-    @test vec(ps) == ComponentVector(component = (x = 1.0, y = 2.0, z = 3.0))
-    @test all(map(==(:group1), ps[:group]))
 end

--- a/SpeedyWeatherInternals/src/ParameterEditing/parameter_table.jl
+++ b/SpeedyWeatherInternals/src/ParameterEditing/parameter_table.jl
@@ -87,11 +87,13 @@ Base.setindex!(ps::ParameterTable, x, nm::Symbol) = setindex!(ps, x, :, nm)
     end
 end
 
-Base.keys(params::ParameterTable) = (:idx, :fieldname, union(map(keys, params)...)...)
+# Workaround for https://github.com/rafaqz/ModelParameters.jl/issues/70
+# Need to iterate over params directly, not the ParameterTable itself
+Base.keys(ps::ParameterTable) = (:idx, :fieldname, union(map(keys, ModelParameters.params(parent(ps)))...)...)
 
-function Base.vec(params::ParameterTable)
+function Base.vec(ps::ParameterTable)
     # recursively unpack params and build component vector
-    return ComponentArray(unpack_params(params))
+    return ComponentArray(stripparams(ps))
 end
 
 # Override internal ModelParameters method _columntypes to condense type names in table schema (just to look nicer)

--- a/SpeedyWeatherInternals/src/ParameterEditing/parameter_table.jl
+++ b/SpeedyWeatherInternals/src/ParameterEditing/parameter_table.jl
@@ -59,8 +59,12 @@ Base.getindex(ps::ParameterTable, nm::Symbol) = getindex(ps, :, nm)
         1:length(ps)
     elseif nm == :fieldname
         ModelParameters.paramfieldnames(ps)
+    elseif any(map(p -> hasproperty(p, nm), ModelParameters.params(ps)))
+        map(ModelParameters.params(ps)) do p
+            hasproperty(p, nm) ? getproperty(p, nm) : nothing
+        end
     else
-        map(p -> getindex(p, nm), ModelParameters.params(ps))
+        error("$nm is not a property of any parameter")
     end
 end
 
@@ -83,7 +87,7 @@ Base.setindex!(ps::ParameterTable, x, nm::Symbol) = setindex!(ps, x, :, nm)
     end
 end
 
-Base.keys(params::ParameterTable) = (:idx, :fieldname, keys(first(params))...)
+Base.keys(params::ParameterTable) = (:idx, :fieldname, union(map(keys, params)...)...)
 
 function Base.vec(params::ParameterTable)
     # recursively unpack params and build component vector

--- a/SpeedyWeatherInternals/src/ParameterEditing/parameterized.jl
+++ b/SpeedyWeatherInternals/src/ParameterEditing/parameterized.jl
@@ -118,7 +118,7 @@ macro parameterized(expr)
     typesig = typedef2sig(typedef)
     # emit parameterof calls for each parsed parameter
     param_constructors = map(params) do info
-        :($(QuoteNode(info.name)) => ParameterEditing.parameterof(obj, Val{$(QuoteNode(info.name))}(); desc = $(info.desc), $(info.attrs)..., kwargs...))
+        :($(QuoteNode(info.name)) => ParameterEditing.parameterof(PT, obj, Val{$(QuoteNode(info.name))}(); desc = $(info.desc), $(info.attrs)..., kwargs...))
     end
     # construct final expression block
     block = Expr(:block)
@@ -134,7 +134,7 @@ macro parameterized(expr)
     push!(block.args, struct_block)
     ## 2. parameters method dispatch
     parameters_func = quote
-        function ParameterEditing.parameters(obj::$(typename); kwargs...)
+        function ParameterEditing.parameters(::Type{PT}, obj::$(typename); kwargs...) where {PT <: AbstractParam}
             param_nt = (; $(param_constructors...))
             nonempty_keys = filter(name -> !isempty(param_nt[name]), keys(param_nt))
             return ParameterEditing.ParameterTable(NamedTuple{nonempty_keys}(map(name -> param_nt[name], nonempty_keys)))

--- a/SpeedyWeatherInternals/src/ParameterEditing/parameterized.jl
+++ b/SpeedyWeatherInternals/src/ParameterEditing/parameterized.jl
@@ -60,7 +60,6 @@ macro parameterized(expr)
     lastdoc = nothing
     typedef = nothing
     has_kwdef = false
-    # defval = nothing
     ## prewalk (top-down) over expression tree; note that there is some danger of infinite
     ## recursion with prewalk since it will descend into the returned expression. However,
     ## this is not a problem here since we only deconstruct/reduce the @param expressions.
@@ -123,8 +122,16 @@ macro parameterized(expr)
     end
     # construct final expression block
     block = Expr(:block)
+    struct_block = Expr(:block)
     ## 1. struct definition
-    push!(block.args, esc(new_expr))
+    # emit the interpolation placeholder $(Expr(:meta, :doc)) so Julia's doc system
+    # will attach any source docstring to the generated struct (same as Base.@kwdef);
+    # for some reason, we need to use a dedicated block for the struct def otherwise it won't work
+    if !has_kwdef
+        push!(struct_block.args, Expr(:meta, :doc))
+    end
+    push!(struct_block.args, esc(new_expr))
+    push!(block.args, struct_block)
     ## 2. parameters method dispatch
     push!(block.args, esc(:(ParameterEditing.parameters(obj::$(typename); kwargs...) = ParameterEditing.ParameterTable((; $(param_constructors...))))))
     ## 3. override ConstructionBase.setproperties if @kwdef is used; we do this so that internal logic in the keyword defaults gets preserved

--- a/SpeedyWeatherInternals/src/ParameterEditing/parameterized.jl
+++ b/SpeedyWeatherInternals/src/ParameterEditing/parameterized.jl
@@ -134,7 +134,7 @@ macro parameterized(expr)
     push!(block.args, struct_block)
     ## 2. parameters method dispatch
     parameters_func = quote
-        function ParameterEditing.parameters(::Type{PT}, obj::$(typename); kwargs...) where {PT <: AbstractParam}
+        function ParameterEditing.parameters(::Type{PT}, obj::$(typename); kwargs...) where {PT <: ParameterEditing.AbstractParam}
             param_nt = (; $(param_constructors...))
             nonempty_keys = filter(name -> !isempty(param_nt[name]), keys(param_nt))
             return ParameterEditing.ParameterTable(NamedTuple{nonempty_keys}(map(name -> param_nt[name], nonempty_keys)))

--- a/SpeedyWeatherInternals/src/ParameterEditing/parameterized.jl
+++ b/SpeedyWeatherInternals/src/ParameterEditing/parameterized.jl
@@ -133,7 +133,14 @@ macro parameterized(expr)
     push!(struct_block.args, esc(new_expr))
     push!(block.args, struct_block)
     ## 2. parameters method dispatch
-    push!(block.args, esc(:(ParameterEditing.parameters(obj::$(typename); kwargs...) = ParameterEditing.ParameterTable((; $(param_constructors...))))))
+    parameters_func = quote
+        function ParameterEditing.parameters(obj::$(typename); kwargs...)
+            param_nt = (; $(param_constructors...))
+            nonempty_keys = filter(name -> !isempty(param_nt[name]), keys(param_nt))
+            return ParameterEditing.ParameterTable(NamedTuple{nonempty_keys}(map(name -> param_nt[name], nonempty_keys)))
+        end
+    end
+    push!(block.args, esc(parameters_func))
     ## 3. override ConstructionBase.setproperties if @kwdef is used; we do this so that internal logic in the keyword defaults gets preserved
     if has_kwdef && typesig.head == :curly
         # handle type arguments; first extract argument names (discarding upper type bounds)

--- a/SpeedyWeatherInternals/src/ParameterEditing/parameters.jl
+++ b/SpeedyWeatherInternals/src/ParameterEditing/parameters.jl
@@ -70,7 +70,7 @@ Convenience method that creates a model parameter from its property with the giv
 A parameter attribute `copmonenttype` is automatically added with value `T`.
 """
 parameterof(obj::T, ::Val{propname}; kwargs...) where {T, propname} = parameterof(NumberParam, obj, Val{propname}(); kwargs...)
-parameterof(::Type{PT}, obj::T, ::Val{propname}; kwargs...) where {PT <: AbstractParam, T, propname} = parameters(PT, getproperty(obj, propname); merge((; kwargs...), (componentttype = T,))...)
+parameterof(::Type{PT}, obj::T, ::Val{propname}; kwargs...) where {PT <: AbstractParam, T, propname} = parameters(PT, getproperty(obj, propname); merge((; kwargs...), (component_type = T,))...)
 
 # reconstruct
 

--- a/SpeedyWeatherInternals/src/ParameterEditing/parameters.jl
+++ b/SpeedyWeatherInternals/src/ParameterEditing/parameters.jl
@@ -56,10 +56,10 @@ attributes(param::NumberParam) = getfield(param, :attrs)
 Extract parameters from the given `obj` as (possibly nested) named-tuple of `NumberParam`s or some other
 `AbstractParam` type. If `obj`
 """
-parameters(obj; kwargs...) = (;)
+parameters(obj; kwargs...) = parameters(NumberParam, obj; kwargs...)
 parameters(param::PT; kwargs...) where {PT <: AbstractParam} = parameters(PT, param; kwargs...)
 parameters(param::Union{Number, AbstractArray}; kwargs...) = parameters(NumberParam, param; kwargs...)
-parameters(::Type{PT}, obj; kwargs...) where {PT <: AbstractParam} = parameters(obj; kwargs...)
+parameters(::Type{PT}, obj; kwargs...) where {PT <: AbstractParam} = (;)
 parameters(::Type{PT}, param::AbstractParam; kwargs...) where {PT <: AbstractParam} = PT(merge(parent(param), kwargs))
 parameters(::Type{PT}, x::Union{Number, AbstractArray}; kwargs...) where {PT <: AbstractParam} = PT(x; kwargs...)
 

--- a/SpeedyWeatherInternals/src/ParameterEditing/parameters.jl
+++ b/SpeedyWeatherInternals/src/ParameterEditing/parameters.jl
@@ -85,6 +85,7 @@ the nested structure must match that of `obj`. This function is used to reconstr
 @inline reconstruct(obj::NamedTuple{keys, V}, values::NamedTuple{keys, V}) where {keys, V <: Tuple} = values
 @inline reconstruct(obj, values::ParameterTable) = reconstruct(obj, stripparams(values))
 @inline reconstruct(obj, values::AbstractArray) = isempty(values) ? obj : error("Cannot reconstruct $(typeof(obj)) from non-empty array of type $(typeof(values))")
+@inline reconstruct(obj, ::NamedTuple{()}) = obj # return obj if named tuple is empty
 @generated function reconstruct(obj, values::Union{NamedTuple, ComponentArray})
     keysof(::Type{<:NamedTuple{keys}}) where {keys} = keys
     keysof(::Type{<:ComponentArray{T, N, A, Tuple{Axis{coords}}}}) where {T, N, A, coords} = keys(coords)

--- a/SpeedyWeatherInternals/test/Project.toml
+++ b/SpeedyWeatherInternals/test/Project.toml
@@ -1,7 +1,10 @@
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+ModelParameters = "4744a3fa-6c31-4707-899e-a3298e4618ad"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/SpeedyWeatherInternals/test/parameters.jl
+++ b/SpeedyWeatherInternals/test/parameters.jl
@@ -21,6 +21,29 @@ import ModelParameters: ModelParameters, Model, Param, params, update
     @test stripparams(p) == 42.0
 end
 
+@testset "reconstruct" begin
+    # primitive identity reconstruction
+    @test reconstruct(1, 1) == 1
+
+    # reconstruct a NamedTuple from a ParameterTable (stripparams path)
+    ps = ParameterTable(a = NumberParam(3.0), b = NumberParam(4.0))
+    obj = (a = 0.0, b = 0.0)
+    @test reconstruct(obj, ps) == (a = 3.0, b = 4.0)
+
+    # reconstruct an AbstractParam (NumberParam) from a scalar value
+    p = NumberParam(1.5)
+    p2 = reconstruct(p, 2.5)
+    @test isa(p2, NumberParam)
+    @test value(p2) == 2.5
+
+    # empty array/named-tuple should return the original object
+    @test reconstruct(obj, Float64[]) === obj
+    @test reconstruct(obj, (;)) === obj
+
+    # non-empty array should throw
+    @test_throws ErrorException reconstruct(obj, [1.0])
+end
+
 @testset "@parameterized" begin
     # test single parameter, no kwdef
     ParameterEditing.@parameterized struct TestType1{T}

--- a/SpeedyWeatherInternals/test/parameters.jl
+++ b/SpeedyWeatherInternals/test/parameters.jl
@@ -76,6 +76,21 @@ end
     @test vec(ps) == ComponentVector(x = 1.0, y = 2.0, z = 3.0)
     @test ps[:desc] == ("parameter 1", "parameter 2", "")
 
+    # test multiple parameters with heterogeneous attributes
+    """Docstring for `TestType5`"""
+    ParameterEditing.@parameterized @kwdef struct TestType5{T1, T2}
+        @param x::T1 = 1.0 (a = 1,)
+        @param y::T1 = 2.0 (b = 2,)
+        @param z::T2 = 3.0 (b = 3,)
+        date::DateTime = DateTime(0)
+    end
+    ps = parameters(TestType5());
+    @test haskey(ps, :a)
+    @test haskey(ps, :b)
+    @test !haskey(ps, :c)
+    @test length(ps) == 3
+    @test vec(ps) == ComponentVector(x = 1.0, y = 2.0, z = 3.0)
+
     # test parameters for nested type
     ParameterEditing.@parameterized @kwdef struct MyModel{T}
         @param component::T = TestType4() (group = :group1,)

--- a/SpeedyWeatherInternals/test/parameters.jl
+++ b/SpeedyWeatherInternals/test/parameters.jl
@@ -1,1 +1,88 @@
+using ComponentArrays: ComponentVector
+using Dates
+using DomainSets: Domain, RealLine, UnitInterval
+using SpeedyWeatherInternals.ParameterEditing
+using SpeedyWeatherInternals.ParameterEditing: NumberParam
 
+import ModelParameters: ModelParameters, Model, Param, params, update
+
+@testset "NumberParam" begin
+    # Test basic construction and getter functions
+    p = NumberParam(42.0, bounds = RealLine(), desc = "Test parameter", unit = "m", category = "generic")
+    @test ParameterEditing.value(p) == p.val == 42.0
+    @test bounds(p) == p.bounds == RealLine()
+    @test description(p) == p.desc == "Test parameter"
+    @test attributes(p) == (unit = "m", category = "generic")
+
+    # Test ModelParameters interface
+    @test params(p) == (p,)
+    @test Model(p)[:val] == (42.0,)
+    @test ParameterEditing.value(update(p, (1.0,))) == 1.0
+    @test stripparams(p) == 42.0
+end
+
+@testset "@parameterized" begin
+    # test single parameter, no kwdef
+    ParameterEditing.@parameterized struct TestType1{T}
+        "non parameter"
+        x::T
+        "parameter"
+        @param y::T
+    end
+    ps = parameters(TestType1(0.0, 1.0))
+    @test length(ps) == 1
+    @test vec(ps).y == 1.0
+    @test ps[:desc] == ("parameter",)
+
+    # test two parameters, no kwdef, also with docstring
+    """Docstring for `TestType2`"""
+    ParameterEditing.@parameterized struct TestType2{TX, TY, TZ}
+        "parameter"
+        @param x::TX
+        "non-parameter"
+        y::TY
+        @param z::TZ
+    end
+    ps = parameters(TestType2(0.0, 1.0, 2.0))
+    @test length(ps) == 2
+    @test vec(ps) == ComponentVector(x = 0.0, z = 2.0)
+    @test ps[:desc] == ("parameter", "")
+
+    # test one parameter, with kwdef and docstrin
+    """Docstring for `TestType3`"""
+    ParameterEditing.@parameterized @kwdef struct TestType3{T}
+        "parameter"
+        @param x::T = 1.0
+        "non-parameter"
+        y::T = 2.0
+    end
+    ps = parameters(TestType3())
+    @test length(ps) == 1
+    @test vec(ps) == ComponentVector(x = 1.0)
+    @test ps[:desc] == ("parameter",)
+
+    # test multiple parameters, with kwdef and docstring
+    """Docstring for `TestType4`"""
+    ParameterEditing.@parameterized @kwdef struct TestType4{T1, T2}
+        "parameter 1"
+        @param x::T1 = 1.0
+        "parameter 2"
+        @param y::T1 = 2.0
+        @param z::T2 = 3.0
+        date::DateTime = DateTime(0)
+    end
+    ps = parameters(TestType4())
+    @test length(ps) == 3
+    @test vec(ps) == ComponentVector(x = 1.0, y = 2.0, z = 3.0)
+    @test ps[:desc] == ("parameter 1", "parameter 2", "")
+
+    # test parameters for nested type
+    ParameterEditing.@parameterized @kwdef struct MyModel{T}
+        @param component::T = TestType4() (group = :group1,)
+    end
+    ps = parameters(MyModel())
+    @test length(ps) == 3
+    @test haskey(parent(ps), :component)
+    @test vec(ps) == ComponentVector(component = (x = 1.0, y = 2.0, z = 3.0))
+    @test all(map(==(:group1), ps[:group]))
+end

--- a/docs/src/differentiability.md
+++ b/docs/src/differentiability.md
@@ -69,7 +69,7 @@ params = parameters(model)
 # output (truncated)
 Parameters:
 ┌───────┬──────────────────────────┬──────────┬────────────┬──────────────────────────────┬─────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────┐
-│   idx │                fieldname │      val │  component │               componentttype │                              bounds │                                                                                     desc │
+│   idx │                fieldname │      val │  component │               component_type │                              bounds │                                                                                     desc │
 │ Int64 │                   Symbol │  Float32 │     Symbol │                     DataType │ IntervalSets.TypedEndpointsInterval │                                                                                   String │
 ├───────┼──────────────────────────┼──────────┼────────────┼──────────────────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
 │     1 │                 rotation │  7.29e-5 │     planet │               Earth{Float32} │       -Inf .. Inf (open) (RealLine) │                                            angular frequency of Earth's rotation [rad/s] │
@@ -106,7 +106,7 @@ param_subset = params[["planet.gravity", "atmosphere.heat_capacity"]]
 
 Parameters:
 ┌───────┬───────────────┬─────────┬────────────┬──────────────────────────┬───────────────────────────────────────┬────────────────────────────────────────────────┐
-│   idx │     fieldname │     val │  component │           componentttype │                                bounds │                                           desc │
+│   idx │     fieldname │     val │  component │           component_type │                                bounds │                                           desc │
 │ Int64 │        Symbol │ Float32 │     Symbol │                 DataType │ DomainSets.HalfLine{Float64, :closed} │                                         String │
 ├───────┼───────────────┼─────────┼────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────────────┤
 │     1 │       gravity │    9.81 │     planet │           Earth{Float32} │   0.0 .. Inf (closed-open) (HalfLine) │             gravitational acceleration [m/s^2] │


### PR DESCRIPTION
The existing implementation of `ParameterTable` does not properly handle the case when some parameters define an attribute and others do not. It simply takes the keys/attributes defined on the `first` parameter as being representative of the whole `ParameterTable`.

This PR adds a quick and dirty solution to handle this within `getindex`. A more elegant solution might be to use the functionality in `ModelParameters` to harmonize all `Param` fields when constructing the `ParameterTable`, but I don't see any concrete reason to prefer this at the moment.

Also adds a workaround for rafaqz/ModelParameters.jl#70