### PR TITLE
Output in Simulation 

### DIFF
--- a/SpeedyWeather/ext/SpeedyWeatherZarrExt.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherZarrExt.jl
@@ -9,10 +9,10 @@ import SpeedyWeather: ZarrOutput, AbstractOutput, AbstractOutputVariable,
     OUTPUT_VARIABLES_DICT, OutputVariablesDict, DEFAULT_NLAYERS_SOIL,
     DEFAULT_OUTPUT_NF, DEFAULT_OUTPUT_INTERVAL, DEFAULT_MISSING_VALUE,
     DEFAULT_COMPRESSION_LEVEL, DEFAULT_KEEPBITS,
-    Variables, Simulation, SpectralGrid, Field,
+    Variables, Simulation, SpectralGrid, Field, CALLBACK_DICT, CallbackDict,
     initialize!, finalize!, output!, write_array!, set!, add!, add_default!,
-    is3D, is_land, hastime, get_indices, scale!, get_soil_layers,
-    get_lond, get_latd, on_architecture, CPU,
+    is3D, is_land, hastime, get_indices, scale!, get_soil_layers, get_nlayers,
+    get_lond, get_latd, on_architecture, CPU, model_class,
     AbstractFullGrid
 
 import SpeedyWeather.RingGrids
@@ -30,19 +30,27 @@ resolve_compressor(::Nothing) = default_zarr_compressor()
 Constructor for [`ZarrOutput`](@ref) (extension version, available once `Zarr.jl`
 is loaded). Behaves like the [`SpeedyWeather.NetCDFOutput`](@ref) constructor:
 builds the output grid, the interpolator, scratch fields and pre-fills the
-`output.variables` dictionary with the defaults for `Model`."""
+`output.variables` dictionary with the defaults for the model's class.
+
+```julia
+using Zarr
+model = PrimitiveWetModel(spectral_grid)
+output = ZarrOutput(model)
+simulation = initialize!(model, output=output)
+```"""
 function ZarrOutput(
-        SG::SpectralGrid,
-        Model::Type{<:AbstractModel} = Barotropic;
-        nlayers_soil = DEFAULT_NLAYERS_SOIL,
+        model::AbstractModel;
         output_grid::AbstractFullGrid = on_architecture(
-            CPU(), RingGrids.full_grid_type(SG.grid)(SG.grid.nlat_half)
+            CPU(), RingGrids.full_grid_type(model.spectral_grid.grid)(model.spectral_grid.grid.nlat_half)
         ),
         output_NF::DataType = DEFAULT_OUTPUT_NF,
+        nlayers_soil::Int = get_soil_layers(model),
         interval::Period = Second(DEFAULT_OUTPUT_INTERVAL),
         compressor = nothing,
         kwargs...
     )
+
+    SG = model.spectral_grid
 
     # INPUT GRID (but on CPU)
     input_grid = on_architecture(CPU(), SG.grid)
@@ -80,7 +88,7 @@ function ZarrOutput(
         kwargs...
     )
 
-    add_default!(output.variables, Model)
+    add_default!(output.variables, model_class(model))
     return output
 end
 
@@ -93,18 +101,12 @@ function initialize!(
         output::ZarrOutput,
         vars::Variables,
         model::AbstractModel,
+        callbacks::CALLBACK_DICT = CallbackDict(),
     )
     output.active || return nothing
 
-    # only checked for models that have a land component
-    if hasfield(typeof(model), :land) && !isnothing(model.land)
-        @assert SpeedyWeather.get_nlayers(model.land) == size(output.field3Dland, 2) "$(size(output.field3Dland, 2))" *
-            " soil layers initialized for output, but $(SpeedyWeather.get_nlayers(model.land)) soil layers initialized for model." *
-            " Please construct ZarrOutput with the same `nlayers_soil` as the model."
-    end
-
     # SHARED INITIALIZATION (run folder, output frequency, counters, callbacks)
-    initialize!(output.core, output, model)
+    initialize!(output.core, output, model, callbacks)
 
     # Total number of output snapshots: IC + one per `output_every_n_steps`.
     n_outputs = vars.prognostic.clock.n_timesteps ÷ output.output_every_n_steps + 1

--- a/SpeedyWeather/src/models/barotropic.jl
+++ b/SpeedyWeather/src/models/barotropic.jl
@@ -26,8 +26,6 @@ $(TYPEDFIELDS)"""
         ST,     # <:SpectralTransform{NF},
         IM,     # <:AbstractImplicit,
         HD,     # <:AbstractHorizontalDiffusion,
-        OU,     # <:AbstractOutput,
-        FB,     # <:AbstractFeedback,
     } <: Barotropic
 
     spectral_grid::SG
@@ -52,11 +50,21 @@ $(TYPEDFIELDS)"""
     spectral_transform::ST = SpectralTransform(spectral_grid)
     implicit::IM = nothing
     horizontal_diffusion::HD = HyperDiffusion(spectral_grid)
+end
 
-    # OUTPUT
-    output::OU = NetCDFOutput(spectral_grid, Barotropic)
-    callbacks::Dict{Symbol, AbstractCallback} = Dict{Symbol, AbstractCallback}()
-    feedback::FB = Feedback()
+"""$(TYPEDSIGNATURES)
+Outer constructor that intercepts the deprecated `output`, `callbacks` and
+`feedback` kwargs. They now live on `Simulation` (pass to `initialize!(model, ...)`)
+and emit a deprecation warning here for backward-compatibility."""
+function BarotropicModel(
+        spectral_grid::SpectralGrid;
+        output = nothing,
+        callbacks = nothing,
+        feedback = nothing,
+        kwargs...,
+    )
+    _warn_deprecated_model_kwargs(:BarotropicModel; output, callbacks, feedback)
+    return BarotropicModel(; spectral_grid, kwargs...)
 end
 
 function variables(model::Barotropic)
@@ -87,19 +95,26 @@ end
 
 """
 $(TYPEDSIGNATURES)
-Calls all `initialize!` functions for most fields, representing components, of `model`,
-except for `model.output` and `model.feedback` which are always called
-at in `time_stepping!`."""
-function initialize!(model::Barotropic; time::DateTime = DEFAULT_DATE)
+Calls all `initialize!` functions for most fields, representing components, of `model`.
+The output writers, callbacks and feedback live on the returned `Simulation` and are
+initialized just before the first time step inside `time_stepping!`."""
+function initialize!(
+        model::Barotropic;
+        time::DateTime = DEFAULT_DATE,
+        output = (),
+        callbacks::CALLBACK_DICT = CallbackDict(),
+        feedback::AbstractFeedback = Feedback(),
+    )
     (; spectral_grid) = model
 
     spectral_grid.nlayers > 1 && @error "Only nlayers=1 supported for BarotropicModel, \
         SpectralGrid with nlayers=$(spectral_grid.nlayers) provided."
 
+    outputs = output_collection(output)
+
     # initialize components
-    arch = model.architecture
     initialize!(model.geometry, model)
-    initialize!(model.time_stepping, model)
+    initialize!(model.time_stepping, model; interval = combined_output_interval(outputs))
     initialize!(model.coriolis, model)
     initialize!(model.forcing, model)
     initialize!(model.drag, model)
@@ -117,5 +132,5 @@ function initialize!(model::Barotropic; time::DateTime = DEFAULT_DATE)
     # now set initial conditions
     initialize!(variables, model)
 
-    return Simulation(variables, model)
+    return Simulation(variables, model, outputs, callbacks, feedback)
 end

--- a/SpeedyWeather/src/models/primitive_dry.jl
+++ b/SpeedyWeather/src/models/primitive_dry.jl
@@ -47,8 +47,6 @@ $(TYPEDFIELDS)"""
         IM,     # <:AbstractImplicit,
         HD,     # <:AbstractHorizontalDiffusion,
         VA,     # <:AbstractVerticalAdvection,
-        OU,     # <:AbstractOutput,
-        FB,     # <:AbstractFeedback,
         TS1,    # <:Tuple{Symbol}
         TS2,    # <:Tuple{Symbol}
         PV,     # <:Val
@@ -104,11 +102,6 @@ $(TYPEDFIELDS)"""
     horizontal_diffusion::HD = HyperDiffusion(spectral_grid)
     vertical_advection::VA = CenteredVerticalAdvection(spectral_grid)
 
-    # OUTPUT
-    output::OU = NetCDFOutput(spectral_grid, PrimitiveDry)
-    callbacks::Dict{Symbol, AbstractCallback} = Dict{Symbol, AbstractCallback}()
-    feedback::FB = Feedback()
-
     # Tuples with symbols pointing at the core components needed to be adapted
     # for availability within the parameterizations
     core_components::TS1 = (
@@ -136,6 +129,21 @@ $(TYPEDFIELDS)"""
     # DERIVED
     # used to infer parameterizations at compile-time
     params::PV = Val(parameterizations)
+end
+
+"""$(TYPEDSIGNATURES)
+Outer constructor that intercepts the deprecated `output`, `callbacks` and
+`feedback` kwargs. They now live on `Simulation` (pass to `initialize!(model, ...)`)
+and emit a deprecation warning here for backward-compatibility."""
+function PrimitiveDryModel(
+        spectral_grid::SpectralGrid;
+        output = nothing,
+        callbacks = nothing,
+        feedback = nothing,
+        kwargs...,
+    )
+    _warn_deprecated_model_kwargs(:PrimitiveDryModel; output, callbacks, feedback)
+    return PrimitiveDryModel(; spectral_grid, kwargs...)
 end
 
 function variables(model::PrimitiveDry)
@@ -190,13 +198,22 @@ end
 
 """
 $(TYPEDSIGNATURES)
-Calls all `initialize!` functions for components of `model`,
-except for `model.output` and `model.feedback` which are always called
-at in `time_stepping!` and `model.implicit` which is done in `first_timesteps!`."""
-function initialize!(model::PrimitiveDry; time::DateTime = DEFAULT_DATE)
+Calls all `initialize!` functions for components of `model`. The output writers,
+callbacks and feedback live on the returned `Simulation` and are initialized just
+before the first time step inside `time_stepping!`. `model.implicit` is initialized
+in `first_timesteps!`."""
+function initialize!(
+        model::PrimitiveDry;
+        time::DateTime = DEFAULT_DATE,
+        output = (),
+        callbacks::CALLBACK_DICT = CallbackDict(),
+        feedback::AbstractFeedback = Feedback(),
+    )
+    outputs = output_collection(output)
+
     # NUMERICS (implicit is initialized later)
     initialize!(model.geometry, model)
-    initialize!(model.time_stepping, model)
+    initialize!(model.time_stepping, model; interval = combined_output_interval(outputs))
     initialize!(model.horizontal_diffusion, model)
 
     # DYNAMICS
@@ -239,7 +256,7 @@ function initialize!(model::PrimitiveDry; time::DateTime = DEFAULT_DATE)
     # set all initial conditions for the ocean, seaice, land then atmosphere
     initialize!(variables, model)
 
-    return Simulation(variables, model)
+    return Simulation(variables, model, outputs, callbacks, feedback)
 end
 
 """$(TYPEDSIGNATURES)

--- a/SpeedyWeather/src/models/primitive_wet.jl
+++ b/SpeedyWeather/src/models/primitive_wet.jl
@@ -50,8 +50,6 @@ $(TYPEDFIELDS)"""
         HD,     # <:AbstractHorizontalDiffusion,
         VA,     # <:AbstractVerticalAdvection,
         HO,     # <:AbstractHoleFilling,
-        OU,     # <:AbstractOutput,
-        FB,     # <:AbstractFeedback,
         TS1,    # <:Tuple{Symbol}
         TS2,    # <:Tuple{Symbol}
         PV,     # <:Val
@@ -110,11 +108,6 @@ $(TYPEDFIELDS)"""
     vertical_advection::VA = CenteredVerticalAdvection(spectral_grid)
     hole_filling::HO = ClipNegatives(spectral_grid)
 
-    # OUTPUT
-    output::OU = NetCDFOutput(spectral_grid, PrimitiveWet)
-    callbacks::Dict{Symbol, AbstractCallback} = Dict{Symbol, AbstractCallback}()
-    feedback::FB = Feedback()
-
     # COMPONENTS
     # Tuples with symbols or instances of all parameterizations and parameter functions
     # Used to initiliaze variables and for the column-based parameterizations
@@ -146,6 +139,21 @@ $(TYPEDFIELDS)"""
     params::PV = Val(parameterizations)
 end
 
+"""$(TYPEDSIGNATURES)
+Outer constructor that intercepts the deprecated `output`, `callbacks` and
+`feedback` kwargs. They now live on `Simulation` (pass to `initialize!(model, ...)`)
+and emit a deprecation warning here for backward-compatibility."""
+function PrimitiveWetModel(
+        spectral_grid::SpectralGrid;
+        output = nothing,
+        callbacks = nothing,
+        feedback = nothing,
+        kwargs...,
+    )
+    _warn_deprecated_model_kwargs(:PrimitiveWetModel; output, callbacks, feedback)
+    return PrimitiveWetModel(; spectral_grid, kwargs...)
+end
+
 function variables(model::PrimitiveWet)
     nsteps = get_prognostic_steps(model.time_stepping)
     return variables(typeof(model), nsteps)
@@ -167,13 +175,22 @@ end
 
 """
 $(TYPEDSIGNATURES)
-Calls all `initialize!` functions for components of `model`,
-except for `model.output` and `model.feedback` which are always called
-at in `time_stepping!` and `model.implicit` which is done in `first_timesteps!`."""
-function initialize!(model::PrimitiveWet; time::DateTime = DEFAULT_DATE)
+Calls all `initialize!` functions for components of `model`. The output writers,
+callbacks and feedback live on the returned `Simulation` and are initialized just
+before the first time step inside `time_stepping!`. `model.implicit` is initialized
+in `first_timesteps!`."""
+function initialize!(
+        model::PrimitiveWet;
+        time::DateTime = DEFAULT_DATE,
+        output = (),
+        callbacks::CALLBACK_DICT = CallbackDict(),
+        feedback::AbstractFeedback = Feedback(),
+    )
+    outputs = output_collection(output)
+
     # NUMERICS (implicit is initialized later)
     initialize!(model.geometry, model)
-    initialize!(model.time_stepping, model)
+    initialize!(model.time_stepping, model; interval = combined_output_interval(outputs))
     initialize!(model.horizontal_diffusion, model)
 
     # DYNAMICS
@@ -218,7 +235,7 @@ function initialize!(model::PrimitiveWet; time::DateTime = DEFAULT_DATE)
     # set all initial conditions for the ocean, sea ice, land then atmosphere
     initialize!(variables, model)
 
-    return Simulation(variables, model)
+    return Simulation(variables, model, outputs, callbacks, feedback)
 end
 
 """$(TYPEDSIGNATURES)

--- a/SpeedyWeather/src/models/shallow_water.jl
+++ b/SpeedyWeather/src/models/shallow_water.jl
@@ -27,8 +27,6 @@ $(TYPEDFIELDS)"""
         ST,     # <:SpectralTransform{NF},
         IM,     # <:AbstractImplicit,
         HD,     # <:AbstractHorizontalDiffusion,
-        OU,     # <:AbstractOutput,
-        FB,     # <:AbstractFeedback,
     } <: ShallowWater
 
     spectral_grid::SG
@@ -54,11 +52,21 @@ $(TYPEDFIELDS)"""
     spectral_transform::ST = SpectralTransform(spectral_grid)
     implicit::IM = ImplicitShallowWater(spectral_grid)
     horizontal_diffusion::HD = HyperDiffusion(spectral_grid)
+end
 
-    # OUTPUT
-    output::OU = NetCDFOutput(spectral_grid, ShallowWater)
-    callbacks::Dict{Symbol, AbstractCallback} = Dict{Symbol, AbstractCallback}()
-    feedback::FB = Feedback()
+"""$(TYPEDSIGNATURES)
+Outer constructor that intercepts the deprecated `output`, `callbacks` and
+`feedback` kwargs. They now live on `Simulation` (pass to `initialize!(model, ...)`)
+and emit a deprecation warning here for backward-compatibility."""
+function ShallowWaterModel(
+        spectral_grid::SpectralGrid;
+        output = nothing,
+        callbacks = nothing,
+        feedback = nothing,
+        kwargs...,
+    )
+    _warn_deprecated_model_kwargs(:ShallowWaterModel; output, callbacks, feedback)
+    return ShallowWaterModel(; spectral_grid, kwargs...)
 end
 
 """($TYPEDSIGNATURES) All variables needed for the shallow water model itself (components excluded)."""
@@ -83,20 +91,29 @@ function variables(model::ShallowWater)
     )
 end
 
-""" 
+"""
 $(TYPEDSIGNATURES)
-Calls all `initialize!` functions for most components (=fields) of `model`,
-except for `model.output` and `model.feedback` which are always initialized
-in `time_stepping!` and `model.implicit` which is done in `first_timesteps!`."""
-function initialize!(model::ShallowWater; time::DateTime = DEFAULT_DATE)
+Calls all `initialize!` functions for most components (=fields) of `model`.
+The output writers, callbacks and feedback live on the returned `Simulation` and
+are initialized just before the first time step inside `time_stepping!`.
+`model.implicit` is initialized in `first_timesteps!`."""
+function initialize!(
+        model::ShallowWater;
+        time::DateTime = DEFAULT_DATE,
+        output = (),
+        callbacks::CALLBACK_DICT = CallbackDict(),
+        feedback::AbstractFeedback = Feedback(),
+    )
     (; spectral_grid) = model
 
     spectral_grid.nlayers > 1 && @error "Only nlayers=1 supported for ShallowWaterModel, \
                                 SpectralGrid with nlayers=$(spectral_grid.nlayers) provided."
 
+    outputs = output_collection(output)
+
     # initialize components
     initialize!(model.geometry, model)
-    initialize!(model.time_stepping, model)
+    initialize!(model.time_stepping, model; interval = combined_output_interval(outputs))
     initialize!(model.coriolis, model)
     initialize!(model.orography, model)
     initialize!(model.forcing, model)
@@ -116,5 +133,5 @@ function initialize!(model::ShallowWater; time::DateTime = DEFAULT_DATE)
     # now set initial conditions
     initialize!(variables, model)
 
-    return Simulation(variables, model)
+    return Simulation(variables, model, outputs, callbacks, feedback)
 end

--- a/SpeedyWeather/src/models/simulation.jl
+++ b/SpeedyWeather/src/models/simulation.jl
@@ -1,15 +1,32 @@
 export Simulation
 
 """$(TYPEDSIGNATURES)
-Simulation is a container struct simply wrapping the variables (prognostic and diagnostic)
-and the model. It contains $(TYPEDFIELDS)"""
-struct Simulation{V, M <: AbstractModel} <: AbstractSimulation{M}
+`Simulation` is a container struct wrapping the variables (prognostic and diagnostic),
+the model, all output writers, callbacks and the runtime feedback. It contains
+$(TYPEDFIELDS)"""
+struct Simulation{V, M <: AbstractModel, O <: Tuple, F} <: AbstractSimulation{M}
     "All variables"
     variables::V
 
     "All model components, containing parameters, constant at runtime"
     model::M
+
+    "Tuple of output writers (`AbstractOutput`) attached to this simulation"
+    output::O
+
+    "Dictionary of callbacks invoked every time step"
+    callbacks::CALLBACK_DICT
+
+    "Runtime feedback (progress meter, NaN detection)"
+    feedback::F
 end
+
+"""$(TYPEDSIGNATURES)
+Minimal constructor for an `AbstractSimulation` with no output writers, an empty
+callback dictionary and a default `Feedback`. Used internally and for backward
+compatibility, e.g. inside `output!` when only `variables` and `model` are known."""
+Simulation(variables, model::AbstractModel) =
+    Simulation(variables, model, (), CallbackDict(), Feedback())
 
 function Base.show(io::IO, S::AbstractSimulation)
     vsize = prettymemory(Base.summarysize(S.variables))
@@ -17,11 +34,82 @@ function Base.show(io::IO, S::AbstractSimulation)
     Ssize = prettymemory(Base.summarysize(S))
     println(io, styled"{warning:Simulation}", "{...} ", styled"{note:($Ssize)}")
     println(io, "├ ", styled"{info:variables}" * "::Variables{...} " * styled"{note:($vsize)}")
-    print(io, "└ ", styled"{info:model}" * "::$(model_type(S.model)){...} " * styled"{note:($Msize)}")
+    println(io, "├ ", styled"{info:model}" * "::$(model_type(S.model)){...} " * styled"{note:($Msize)}")
+
+    # output writers: show one line per attached writer, using only the short
+    # (non-parameterized) type name — mirrors how AbstractModel show truncates
+    # parameter chains. Falls back to "(none)" when no writer is attached.
+    nout = length(S.output)
+    if nout == 0
+        println(io, "├ ", styled"{info:output}" * "::Tuple{} " * styled"{note:(none)}")
+    else
+        println(io, "├ ", styled"{info:output}" * "::Tuple of $nout writer(s)")
+        for (i, writer) in enumerate(S.output)
+            branch = i == nout ? "│ └" : "│ ├"
+            short = split(string(typeof(writer)), "{", limit = 2)[1]
+            status = writer.active ? "active" : "inactive"
+            println(io, "$branch ", styled"{magenta:$short} " * styled"{note:($status)}")
+        end
+    end
+
+    println(io, "├ ", styled"{info:callbacks}" * "::Dict of $(length(S.callbacks)) callback(s)")
+    print(io, "└ ", styled"{info:feedback}" * "::$(nameof(typeof(S.feedback)))")
     return nothing
 end
 
 unpack(sim::AbstractSimulation) = (sim.variables, sim.model)
+
+"""$(TYPEDSIGNATURES)
+Normalize the `output` argument passed to `initialize!`/`Simulation` to a `Tuple` of
+`AbstractOutput` writers. Accepts a single writer, a tuple of writers, or `nothing`.
+When more than one writer is given, all writers must share the same `interval` —
+the model time step is rounded to a divisor of this single interval, so allowing
+mismatched intervals would silently desynchronise the writers' time axes."""
+output_collection(::Nothing) = ()
+output_collection(o::AbstractOutput) = (o,)
+function output_collection(outputs::Tuple)
+    length(outputs) <= 1 && return outputs
+    first_interval = first(outputs).interval
+    for (i, o) in enumerate(outputs)
+        o.interval == first_interval || throw(ArgumentError(
+            "All output writers must share the same `interval`. " *
+                "Writer 1 has interval=$(first_interval) but writer $i has interval=$(o.interval). " *
+                "Construct your writers with the same `interval` keyword."
+        ))
+    end
+    return outputs
+end
+
+"""$(TYPEDSIGNATURES)
+Return the output `interval` used to round the model time step to a divisor. All
+attached writers share the same `interval` (enforced by `output_collection`).
+Falls back to `DEFAULT_OUTPUT_INTERVAL` when no writers are attached."""
+combined_output_interval(::Tuple{}) = Second(DEFAULT_OUTPUT_INTERVAL)
+combined_output_interval(outputs::Tuple) = first(outputs).interval
+
+"""$(TYPEDSIGNATURES)
+Emit a deprecation warning if any of the deprecated kwargs `output`, `callbacks`,
+or `feedback` is passed to a model constructor. These now live on `Simulation`
+and are passed to `initialize!(model, output=..., callbacks=..., feedback=...)`."""
+function _warn_deprecated_model_kwargs(model_name::Symbol; output, callbacks, feedback)
+    isnothing(output) || Base.depwarn(
+        "Passing `output` to $(model_name)(...) is deprecated; it is ignored. " *
+            "Construct the output writer (e.g. `NetCDFOutput(model)`) and pass it to " *
+            "`initialize!(model, output=...)` instead.",
+        model_name,
+    )
+    isnothing(callbacks) || Base.depwarn(
+        "Passing `callbacks` to $(model_name)(...) is deprecated; it is ignored. " *
+            "Pass to `initialize!(model, callbacks=...)` instead.",
+        model_name,
+    )
+    isnothing(feedback) || Base.depwarn(
+        "Passing `feedback` to $(model_name)(...) is deprecated; it is ignored. " *
+            "Pass to `initialize!(model, feedback=...)` instead.",
+        model_name,
+    )
+    return nothing
+end
 
 const DEFAULT_PERIOD = Day(10)
 const DEFAULT_TIMESTEPS = -1    # -1 means unspecified = use the period kwarg
@@ -46,17 +134,17 @@ end
 unicodeplot(x) = nothing
 
 """$(TYPEDSIGNATURES)
-Initializes a `simulation`. Scales the variables, initializes
-the output, stores initial conditions, initializes the progress meter feedback,
-callbacks and performs the first two initial time steps to spin up the
-leapfrogging scheme."""
+Initializes a `simulation` (does not include the construction step from `model`).
+Scales the variables, initializes the output, stores initial conditions, initializes
+the progress meter feedback, callbacks and performs the first two initial time steps
+to spin up the leapfrogging scheme."""
 function initialize!(
         simulation::AbstractSimulation;
         period::Period = DEFAULT_PERIOD,
         steps::Int = DEFAULT_TIMESTEPS,
         output::Bool = false,
     )
-    (; variables, model) = simulation
+    (; variables, model, callbacks) = simulation
     progn = variables.prognostic
 
     # SET THE CLOCK
@@ -71,8 +159,10 @@ function initialize!(
         initialize!(clock, time_stepping, period)
     end
 
-    # OUTPUT, enable/disable output
-    set!(simulation.model.output, active = output, reset_path = true)
+    # OUTPUT, enable/disable every attached writer
+    for writer in simulation.output
+        set!(writer, active = output, reset_path = true)
+    end
 
     # SCALING: we use vorticity*radius, divergence*radius in the dynamical core
     scale_prognostic!(variables, model.planet.radius)
@@ -94,8 +184,10 @@ function initialize!(
     haskey(progn, :particles) && initialize!(variables, progn.particles, model)     # initialize particle work arrays
 
     # only initialize output and callbacks just before the simulation starts
-    initialize!(model.output, variables, model)
-    initialize!(model.callbacks, variables, model)
+    for writer in simulation.output
+        initialize!(writer, variables, model, callbacks)
+    end
+    initialize!(callbacks, simulation)
     return simulation
 end
 
@@ -103,10 +195,12 @@ end
 Finalize a `simulation`. Finishes the progress meter, unscales variables,
 finalizes the output, writes a restart file and finalizes callbacks."""
 function finalize!(simulation::AbstractSimulation)
-    (; variables, model) = simulation
-    finalize!(model.feedback)                       # finish the progress meter, do first for benchmark accuracy
+    (; variables, callbacks, feedback) = simulation
+    finalize!(feedback)                             # finish the progress meter, do first for benchmark accuracy
     unscale!(variables)                             # undo radius-scaling for vor, div in the dynamical core
-    finalize!(model.output, simulation)             # possibly post-process output, then close netCDF file
-    finalize!(model.callbacks, variables, model)    # any callbacks to finalize?
+    for writer in simulation.output
+        finalize!(writer, simulation)               # possibly post-process output, then close netCDF/Zarr file
+    end
+    finalize!(callbacks, simulation)                # any callbacks to finalize?
     return simulation
 end

--- a/SpeedyWeather/src/output/callbacks.jl
+++ b/SpeedyWeather/src/output/callbacks.jl
@@ -28,12 +28,12 @@ initialize!(::NoCallback, args...) = nothing     # executed once before the main
 callback!(::NoCallback, args...) = nothing       # executed after every time step
 finalize!(::NoCallback, args...) = nothing       # executed after main time loop finishes
 
-# simply loop over dict of callbacks
+# simply loop over dict of callbacks, passing the simulation through to each callback
 for func in (:initialize!, :callback!, :finalize!)
     @eval begin
-        function $func(callbacks::CALLBACK_DICT, args...)
+        function $func(callbacks::CALLBACK_DICT, simulation::AbstractSimulation)
             for key in keys(callbacks)
-                $func(callbacks[key], args...)
+                $func(callbacks[key], simulation)
             end
             return
         end
@@ -45,8 +45,8 @@ export add!
 $(TYPEDSIGNATURES)
 Add a or several callbacks to a Dict{String, AbstractCallback} dictionary. To be used like
 
-    add!(model.callbacks, :my_callback => callback)
-    add!(model.callbacks, :my_callback1 => callback, :my_callback2 => other_callback)
+    add!(simulation.callbacks, :my_callback => callback)
+    add!(simulation.callbacks, :my_callback1 => callback, :my_callback2 => other_callback)
 """
 function add!(D::CALLBACK_DICT, key_callbacks::Pair{Symbol, <:AbstractCallback}...)
     for key_callback in key_callbacks
@@ -59,16 +59,12 @@ end
 
 """
 $(TYPEDSIGNATURES)
-Add a or several callbacks to a model::AbstractModel. To be used like
-
-    add!(model, :my_callback => callback)
-    add!(model, :my_callback1 => callback, :my_callback2 => other_callback)
-"""
-add!(model::AbstractModel, key_callbacks::Pair{Symbol, <:AbstractCallback}...) =
-    add!(model.callbacks, key_callbacks...)
+Add a or several callbacks to a `simulation::AbstractSimulation`."""
+add!(sim::AbstractSimulation, key_callbacks::Pair{Symbol, <:AbstractCallback}...) =
+    add!(sim.callbacks, key_callbacks...)
 add!(D::CALLBACK_DICT, key::Symbol, callback::AbstractCallback) = add!(D, Pair(key, callback))
-add!(model::AbstractModel, key::Symbol, callback::AbstractCallback) =
-    add!(model.callbacks, Pair(key, callback))
+add!(sim::AbstractSimulation, key::Symbol, callback::AbstractCallback) =
+    add!(sim.callbacks, Pair(key, callback))
 
 
 # also with string but flag conversion
@@ -83,8 +79,8 @@ $(TYPEDSIGNATURES)
 Add a or several callbacks to a Dict{Symbol, AbstractCallback} dictionary without specifying the
 key which is randomly created like callback_????. To be used like
 
-    add!(model.callbacks, callback)
-    add!(model.callbacks, callback1, callback2)."""
+    add!(simulation.callbacks, callback)
+    add!(simulation.callbacks, callback1, callback2)."""
 function add!(D::CALLBACK_DICT, callbacks::AbstractCallback...; verbose = true)
     for callback in callbacks
         key = Symbol("callback_" * Random.randstring(4))
@@ -96,16 +92,16 @@ end
 
 """
 $(TYPEDSIGNATURES)
-Add a or several callbacks to a mdoel without specifying the
+Add a or several callbacks to a `simulation::AbstractSimulation` without specifying the
 key which is randomly created like callback_????. To be used like
 
-    add!(model.callbacks, callback)
-    add!(model.callbacks, callback1, callback2)."""
-add!(model::AbstractModel, callbacks::AbstractCallback...) =
-    add!(model.callbacks, callbacks..., verbose = model.feedback.verbose)
+    add!(simulation, callback)
+    add!(simulation, callback1, callback2)."""
+add!(sim::AbstractSimulation, callbacks::AbstractCallback...) =
+    add!(sim.callbacks, callbacks..., verbose = sim.feedback.verbose)
 
 # adding via tuple splats the tuple
-add!(model::AbstractModel, tuple::Tuple) = add!(model, tuple...)
+add!(sim::AbstractSimulation, tuple::Tuple) = add!(sim, tuple...)
 
 # delete!(dict, key) already defined in Base
 
@@ -128,9 +124,9 @@ Allocates vector of correct length (number of elements = total time steps plus o
 global surface temperature of the initial conditions"""
 function initialize!(
         callback::GlobalSurfaceTemperatureCallback{NF},
-        vars::Variables,
-        model::AbstractModel,
+        simulation::AbstractSimulation,
     ) where {NF}
+    vars, model = simulation.variables, simulation.model
     callback.temperature = Vector{NF}(undef, vars.prognostic.clock.n_timesteps + 1)    # replace with vector of correct length
     nlayers = model.geometry.nlayers
     callback.temperature[1] = vars.grid.temp_average[nlayers]       # set initial conditions
@@ -144,9 +140,9 @@ Pulls the average temperature from the lowermost layer and stores it in the next
 element of the callback.temperature vector."""
 function callback!(
         callback::GlobalSurfaceTemperatureCallback,
-        vars::Variables,
-        model::AbstractModel,
+        simulation::AbstractSimulation,
     )
+    vars, model = simulation.variables, simulation.model
     callback.timestep_counter += 1
     i = callback.timestep_counter
     nlayers = model.geometry.nlayers

--- a/SpeedyWeather/src/output/feedback.jl
+++ b/SpeedyWeather/src/output/feedback.jl
@@ -51,7 +51,10 @@ end
 """
 $(TYPEDSIGNATURES)
 Initializes the a `Feedback` struct."""
-function initialize!(feedback::Feedback, clock::Clock, model::AbstractModel)
+function initialize!(feedback::Feedback, simulation::AbstractSimulation)
+    (; model) = simulation
+    (; clock) = simulation.variables.prognostic
+
     # set to false to recheck for NaNs
     feedback.nans_detected = false
 
@@ -65,10 +68,14 @@ function initialize!(feedback::Feedback, clock::Clock, model::AbstractModel)
     FEEDBACK_TMIN[] = -1
     FEEDBACK_TMAX[] = -300  # in °C
 
+    # description includes the run folder of the first active output writer, if any
+    active_output = first_active_output(simulation)
+    run_folder_str = isnothing(active_output) ? " " : " $(active_output.run_folder) "
+
     # reinitalize progress meter, minus one to exclude first_timesteps! which contain compilation
     # only do now for benchmark accuracy
     (; showspeed, description, verbose, feedback_dt) = feedback
-    desc = description * (model.output.active ? " $(model.output.run_folder) " : " ")
+    desc = description * run_folder_str
     feedback.progress_meter = ProgressMeter.Progress(
         clock.n_timesteps - 1;
         enabled = verbose,
@@ -84,7 +91,26 @@ function initialize!(feedback::Feedback, clock::Clock, model::AbstractModel)
 end
 
 # fallback if feedback is set to nothing
-initialize!(::Nothing, clock::Clock, model::AbstractModel) = nothing
+initialize!(::Nothing, simulation::AbstractSimulation) = nothing
+
+"""$(TYPEDSIGNATURES)
+Returns the first active output writer attached to `simulation`, or `nothing` if
+no writer is active."""
+function first_active_output(simulation::AbstractSimulation)
+    for writer in simulation.output
+        writer.active && return writer
+    end
+    return nothing
+end
+
+"""$(TYPEDSIGNATURES)
+Returns `true` if any output writer in `simulation.output` is active."""
+function any_output_active(simulation::AbstractSimulation)
+    for writer in simulation.output
+        writer.active && return true
+    end
+    return false
+end
 
 progress!(feedback::Feedback) = ProgressMeter.next!(feedback.progress_meter)
 
@@ -194,25 +220,19 @@ export ParametersTxt
 """ParametersTxt callback. Writes a parameters.txt file with all model parameters.
 Options are $(TYPEDFIELDS)"""
 @kwdef mutable struct ParametersTxt <: AbstractCallback
-    "[OPTION] Path for parameters.txt file, uses model.output.run_path if not specified"
+    "[OPTION/DERIVED] Path for parameters.txt file. Set by the output writer at initialize!."
     path::String = ""
 
     "[OPTION] File name for parameters.txt file"
     filename::String = "parameters.txt"
-
-    "[OPTION] Only write with model.output.active = true?"
-    write_only_with_output::Bool = true
 end
 
 """$(TYPEDSIGNATURES)
 Initialize ParametersTxt by writing the model parameters (via defined show of model components) into a text file."""
-function initialize!(parameters_txt::ParametersTxt, vars, model)
-
-    # escape in case of no output
-    parameters_txt.write_only_with_output && (model.output.active || return nothing)
-
-    (; filename) = parameters_txt
-    path = parameters_txt.path == "" ? model.output.run_path : parameters_txt.path
+function initialize!(parameters_txt::ParametersTxt, simulation::AbstractSimulation)
+    (; model) = simulation
+    (; filename, path) = parameters_txt
+    isempty(path) && return nothing
     mkpath(path)
 
     # also export parameters into run????/parameters.txt
@@ -222,8 +242,6 @@ function initialize!(parameters_txt::ParametersTxt, vars, model)
         println(file, getfield(model, property), "\n")
     end
     close(file)
-
-    model.output.active || @info "Parameter summary written to $(joinpath(path, filename)) although output=false"
     return nothing
 end
 
@@ -236,14 +254,11 @@ export ProgressTxt
 """ProgressTxt callback. Writes a progress.txt file with time stepping progress.
 Options are $(TYPEDFIELDS)"""
 @kwdef mutable struct ProgressTxt <: AbstractCallback
-    "[OPTION] Path for progress.txt file, uses model.output.run_path if not specified"
+    "[OPTION/DERIVED] Path for progress.txt file. Set by the output writer at initialize!."
     path::String = ""
 
     "[OPTION] File name for progress.txt file"
     filename::String = "progress.txt"
-
-    "[OPTION] Only write with model.output.active = true?"
-    write_only_with_output::Bool = true
 
     "[OPTION] Every n% of time steps write to progress.txt, default is 5%"
     every_n_percent::Int = 5
@@ -254,15 +269,16 @@ end
 
 """$(TYPEDSIGNATURES)
 Initializes the ProgressTxt callback by creating a progress.txt file and writing some initial information to it."""
-function initialize!(progress_txt::ProgressTxt, vars, model)
-    # escape in case of no output
-    progress_txt.write_only_with_output && (model.output.active || return nothing)
+function initialize!(progress_txt::ProgressTxt, simulation::AbstractSimulation)
+    (; model) = simulation
+    vars = simulation.variables
 
-    (; filename) = progress_txt
-    path = progress_txt.path == "" ? model.output.run_path : progress_txt.path
+    (; filename, path) = progress_txt
+    isempty(path) && return nothing
     mkpath(path)
 
-    (; run_folder, run_path) = model.output
+    active_output = first_active_output(simulation)
+    run_folder = isnothing(active_output) ? "" : active_output.run_folder
     SG = model.spectral_grid
     L = model.time_stepping
     days = Second(vars.prognostic.clock.period).value / (3600 * 24)
@@ -275,22 +291,21 @@ function initialize!(progress_txt::ProgressTxt, vars, model)
     write(file, "Integrating:\n")
     write(file, "$SG\n")
     write(file, "Time: $days days at Δt = $(L.Δt_sec)s\n")
-    model.output.active && write(file, "\nAll data will be stored in $run_path\n")
-    model.output.active || write(file, "\nNo output will be written (output=false)\n")
+    if !isnothing(active_output)
+        write(file, "\nAll data will be stored in $(active_output.run_path)\n")
+    end
     progress_txt.file = file
-
-    model.output.active || @info "Progress is being written to $(joinpath(path, filename)) although output=false"
     return nothing
 end
 
 """$(TYPEDSIGNATURES)
 Writes the time stepping progress to the progress.txt file every `every_n_percent` % of time steps."""
-function callback!(progress_txt::ProgressTxt, vars, model)
-    # escape in case of no output
-    progress_txt.write_only_with_output && (model.output.active || return nothing)
-    isnothing(model.feedback) && return nothing
+function callback!(progress_txt::ProgressTxt, simulation::AbstractSimulation)
+    isempty(progress_txt.path) && return nothing
+    feedback = simulation.feedback
+    isnothing(feedback) && return nothing
 
-    (; progress_meter, nans_detected) = model.feedback
+    (; progress_meter, nans_detected) = feedback
     (; counter, n) = progress_meter
     (; file, every_n_percent) = progress_txt
 
@@ -315,13 +330,13 @@ end
 
 """$(TYPEDSIGNATURES)
 Finalizes the ProgressTxt callback by writing the total time taken to the progress.txt file and closing it."""
-function finalize!(progress_txt::ProgressTxt, vars, model)
-    # escape in case of no output
-    progress_txt.write_only_with_output && (model.output.active || return nothing)
-    isnothing(model.feedback) && return nothing
+function finalize!(progress_txt::ProgressTxt, simulation::AbstractSimulation)
+    isempty(progress_txt.path) && return nothing
+    feedback = simulation.feedback
+    isnothing(feedback) && return nothing
 
     (; file) = progress_txt
-    (; progress_meter) = model.feedback
+    (; progress_meter) = feedback
 
     time_elapsed = progress_meter.tlast - progress_meter.tinit
     s = "\nIntegration done in $(readable_secs(time_elapsed))."

--- a/SpeedyWeather/src/output/particle_tracker.jl
+++ b/SpeedyWeather/src/output/particle_tracker.jl
@@ -4,7 +4,7 @@ export ParticleTracker
 A ParticleTracker is implemented as a callback to output the trajectories
 of particles from particle advection. To be added like
 
-    add!(model.callbacks, ParticleTracker(spectral_grid; kwargs...))
+    add!(simulation, ParticleTracker(spectral_grid; kwargs...))
 
 Output done via netCDF. Fields and options are
 $(TYPEDFIELDS)"""
@@ -15,7 +15,7 @@ $(TYPEDFIELDS)"""
     "[OPTION] File name for netCDF file"
     filename::String = "particles.nc"
 
-    "[OPTION] Path for netCDF file, uses model.output.run_path if not specified"
+    "[OPTION] Path for netCDF file. Falls back to the first active output writer's run_path."
     path::String = ""
 
     "[OPTION] lossless compression level; 1=low but fast, 9=high but slow"
@@ -47,18 +47,23 @@ end
 
 function initialize!(
         particle_tracker::ParticleTracker,
-        vars::Variables,
-        model::AbstractModel,
+        simulation::AbstractSimulation,
     )
+    (; model) = simulation
+    vars = simulation.variables
 
     (; clock) = vars.prognostic
     initialize!(particle_tracker.schedule, clock)
 
     # CREATE NETCDF FILE, vector of NcVars for output
     (; filename) = particle_tracker
-    path = particle_tracker.path == "" ? model.output.run_path : particle_tracker.path
+    if isempty(particle_tracker.path)
+        active_output = first_active_output(simulation)
+        particle_tracker.path = isnothing(active_output) ? pwd() : active_output.run_path
+    end
+    path = particle_tracker.path
     mkpath(path)
-    model.output.active || @info "ParticleTracker writes to $(joinpath(path, filename)) as output=false"
+    any_output_active(simulation) || @info "ParticleTracker writes to $(joinpath(path, filename)) as output=false"
 
     dataset = NCDataset(joinpath(path, filename), "c")
     particle_tracker.netcdf_file = dataset
@@ -134,9 +139,9 @@ end
 
 function callback!(
         particle_tracker::ParticleTracker,
-        vars::Variables,
-        model::AbstractModel,
+        simulation::AbstractSimulation,
     )
+    vars = simulation.variables
     isscheduled(particle_tracker.schedule, vars.prognostic.clock) || return nothing   # else escape immediately
     i = particle_tracker.schedule.counter + 1     # +1 for initial conditions (not scheduled)
 

--- a/SpeedyWeather/src/output/restart.jl
+++ b/SpeedyWeather/src/output/restart.jl
@@ -6,14 +6,11 @@ on the last time step as jld2 file. Options are $(TYPEDFIELDS)"""
     "[OPTION] File name for restart file, should end with .jld2"
     filename::String = "restart.jld2"
 
-    "[OPTION] Path for restart file, uses model.output.run_path if not specified"
+    "[OPTION/DERIVED] Path for restart file. Set by the output writer at initialize!."
     path::String = ""
 
     "[OPTION] Apply lossless compression in JLD2?"
     compress::Bool = true
-
-    "[OPTION] Only write with model.output.active = true?"
-    write_only_with_output::Bool = true
 
     "[DERIVED] package version to track possible incompatibilities"
     pkg_version::VersionNumber = isnothing(pkgversion(SpeedyWeather)) ? v"0.0.0" : pkgversion(SpeedyWeather)
@@ -30,18 +27,13 @@ to the output folder (or current path) that can be used to restart the model.
 Variables in restart file are not scaled."""
 function finalize!(
         restart::WriteVariablesRestartFile,
-        vars::Variables,
-        model::AbstractModel,
+        simulation::AbstractSimulation,
     )
-    # escape in case of no output
-    restart.write_only_with_output && (model.output.active || return nothing)
+    isempty(restart.path) && return nothing
 
-    (; compress, filename) = restart
-
-    # use output run path if not specified
-    path = restart.path == "" ? model.output.run_path : restart.path
+    (; compress, filename, path) = restart
+    vars = simulation.variables
     mkpath(path)
-    restart.path = path     # update path in case it was empty before
 
     jldopen(joinpath(path, filename), "w"; compress) do f
         f["variables.prognostic"] = vars.prognostic
@@ -49,7 +41,7 @@ function finalize!(
         f["description"] = "Restart file created by SpeedyWeather.jl"
     end
 
-    return model.output.active || @info "Restart file written to $(joinpath(path, filename)) although output=false"
+    return nothing
 end
 
 export WriteModelComponentFile
@@ -61,14 +53,11 @@ component at the end of the simulation. Options are $(TYPEDFIELDS)"""
     "[OPTION] File name for model component restart file, should end with .jld2"
     filename::String = "model_component.jld2"
 
-    "[OPTION] Path for restart file, uses model.output.run_path if not specified"
+    "[OPTION/DERIVED] Path for restart file. If left empty, writes to current directory."
     path::String = ""
 
     "[OPTION] Apply lossless compression in JLD2?"
     compress::Bool = true
-
-    "[OPTION] Only write with model.output.active = true?"
-    write_only_with_output::Bool = true
 
     "[OPTION] Model component to write, to be passed on as keyword argument to the callback"
     component::C
@@ -86,18 +75,17 @@ to the output folder (or current path) that can be used to restart the model.
 With the `component` field in `WriteModelComponentFile` as at the end of the simulation."""
 function finalize!(
         restart::WriteModelComponentFile,
-        ::Variables,
-        model::AbstractModel,
+        simulation::AbstractSimulation,
     )
-    # escape in case of no output
-    restart.write_only_with_output && (model.output.active || return nothing)
-
     (; compress, filename) = restart
 
-    # use output run path if not specified
-    path = restart.path == "" ? model.output.run_path : restart.path
+    # use first active output writer's run path if no path specified
+    if isempty(restart.path)
+        active_output = first_active_output(simulation)
+        restart.path = isnothing(active_output) ? pwd() : active_output.run_path
+    end
+    path = restart.path
     mkpath(path)
-    restart.path = path     # update path in case it was empty before
 
     jldopen(joinpath(path, filename), "w"; compress) do f
         f["component"] = restart.component
@@ -105,7 +93,7 @@ function finalize!(
         f["description"] = "Model component file created by SpeedyWeather.jl"
     end
 
-    return model.output.active || @info "Model component file written to $(joinpath(path, filename)) although output=false"
+    return nothing
 end
 
 load_model_component(callback::WriteModelComponentFile) =

--- a/SpeedyWeather/src/output/writers/general.jl
+++ b/SpeedyWeather/src/output/writers/general.jl
@@ -30,13 +30,6 @@ function add!(output::AbstractOutput, outputvariables::AbstractOutputVariable...
 end
 
 """$(TYPEDSIGNATURES)
-Add `outputvariables` to the dictionary in `output::NetCDFOutput` of `model`, i.e. at `model.output.variables`."""
-function add!(model::AbstractModel, outputvariables::AbstractOutputVariable...)
-    add!(model.output, outputvariables...)
-    return model.output
-end
-
-"""$(TYPEDSIGNATURES)
 Delete output variables from `output` by their (short name) (Symbol or String), corresponding
 to the keys in the dictionary."""
 function Base.delete!(output::AbstractOutput, keys::Union{String, Symbol}...)
@@ -99,9 +92,6 @@ end
 
 # fallback for nothing output
 set!(::Nothing; active, reset_path = true) = nothing
-
-# fallback for nothing output
-initialize!(::Nothing, ::Union{AbstractFeedback, Nothing}, ::Variables, ::AbstractModel) = nothing
 
 # in case of no output nothing to close
 Base.close(::Nothing) = nothing
@@ -211,24 +201,26 @@ Returns the full path of the output file after it was created."""
 get_full_output_file_path(output::AbstractOutput) = joinpath(output.run_path, output.filename)
 
 """$(TYPEDSIGNATURES)
-Returns the full path of the output file for a `simulation`. Throws an error if output is not active."""
+Returns the full path of the first active output writer attached to `simulation`.
+Throws an error if no writer is active."""
 function get_output_path(simulation::AbstractSimulation)
-    output = simulation.model.output
-    output.active || error("Output is not active")
+    output = first_active_output(simulation)
+    isnothing(output) && error("Output is not active")
     return joinpath(output.run_path, output.filename)
 end
 
 """$(TYPEDSIGNATURES)
-Loads a `var_name` trajectory of the model `M` that has been saved in
-a netCDF file during the time stepping."""
-function load_trajectory(var_name::Union{Symbol, String}, model::AbstractModel)
-    @assert model.output.active "Output is turned off"
-    return Array(NCDataset(get_full_output_file_path(model.output))[string(var_name)])
+Loads a `var_name` trajectory of `simulation` that has been saved in
+a netCDF file during the time stepping. Reads from the first active NetCDFOutput."""
+function load_trajectory(var_name::Union{Symbol, String}, simulation::AbstractSimulation)
+    output = first_active_output(simulation)
+    @assert !isnothing(output) "Output is turned off"
+    return Array(NCDataset(get_full_output_file_path(output))[string(var_name)])
 end
 
 """
 $(TYPEDSIGNATURES)
-Returns the output time step of the model `M`."""
+Returns the output time step of `output`."""
 function get_interval(output::AbstractOutput)
     return output.interval
 end

--- a/SpeedyWeather/src/output/writers/netcdf_output.jl
+++ b/SpeedyWeather/src/output/writers/netcdf_output.jl
@@ -48,7 +48,7 @@ $(TYPEDFIELDS)"""
     write_progress_txt::Bool = true
 
     # WHAT/WHEN OPTIONS
-    "[DERIVD] start date of the simulation, used for time dimension in netcdf file"
+    "[DERIVED] start date of the simulation, used for time dimension in netcdf file"
     startdate::DT = DateTime(2000, 1, 1)
 
     "[OPTION] output frequency, time step"
@@ -70,21 +70,28 @@ end
 
 """
 $(TYPEDSIGNATURES)
-Constructor for NetCDFOutput based on `S::SpectralGrid` and optionally
-the `Model` type (e.g. `ShallowWater`, `PrimitiveWet`) as second positional argument. In case a 
-non-default number of soil layers is used, it also needs the respective `nlayers_soil` to allocate those outputs.
-The output grid is optionally determined by keyword arguments `output_Grid` (its type, full grid required),
-`nlat_half` (resolution) and `output_NF` (number format). By default, uses the full grid
-equivalent of the grid and resolution used in `SpectralGrid` `S`."""
+Construct a [`NetCDFOutput`](@ref) from a fully constructed `model::AbstractModel`,
+inferring spectral grid, number of soil layers and default output variables from
+the model. Optional keyword arguments control output grid/resolution, output number
+format, output interval and per-file options.
+
+```julia
+model = PrimitiveWetModel(spectral_grid)
+output = NetCDFOutput(model)
+simulation = initialize!(model, output=output)
+```"""
 function NetCDFOutput(
-        SG::SpectralGrid,
-        Model::Type{<:AbstractModel} = Barotropic;
-        nlayers_soil = DEFAULT_NLAYERS_SOIL,
-        output_grid::AbstractFullGrid = on_architecture(CPU(), RingGrids.full_grid_type(SG.grid)(SG.grid.nlat_half)),
+        model::AbstractModel;
+        output_grid::AbstractFullGrid = on_architecture(
+            CPU(), RingGrids.full_grid_type(model.spectral_grid.grid)(model.spectral_grid.grid.nlat_half)
+        ),
         output_NF::DataType = DEFAULT_OUTPUT_NF,
-        interval::Period = Second(DEFAULT_OUTPUT_INTERVAL),  # only needed for dispatch
+        nlayers_soil::Int = get_soil_layers(model),
+        interval::Period = Second(DEFAULT_OUTPUT_INTERVAL),
         kwargs...
     )
+
+    SG = model.spectral_grid
 
     # INPUT GRID (but on CPU)
     input_grid = on_architecture(CPU(), SG.grid)
@@ -94,7 +101,6 @@ function NetCDFOutput(
 
     # CREATE FULL FIELDS TO INTERPOLATE ONTO BEFORE WRITING DATA OUT
     (; nlayers) = SG
-
     field2D = Field(output_NF, output_grid)
     field3D = Field(output_NF, output_grid, nlayers)
     field3Dland = Field(output_NF, output_grid, nlayers_soil)
@@ -108,8 +114,25 @@ function NetCDFOutput(
         kwargs...
     )
 
-    add_default!(output.variables, Model)
+    # fill the default output variables for this model class if no variables provided
+    if isempty(output.variables)
+        add_default!(output.variables, model_class(model))
+    end
     return output
+end
+
+"""$(TYPEDSIGNATURES)
+Deprecated stub: the old `NetCDFOutput(spectral_grid, ModelType)` constructor has
+been replaced by `NetCDFOutput(model::AbstractModel)`. Construct the model first,
+then pass it to `NetCDFOutput`."""
+function NetCDFOutput(::SpectralGrid, args...; kwargs...)
+    error(
+        "`NetCDFOutput(spectral_grid, ...)` has been removed. Construct the model " *
+            "first and call `NetCDFOutput(model)` instead, e.g.\n" *
+            "    model = PrimitiveWetModel(spectral_grid)\n" *
+            "    output = NetCDFOutput(model)\n" *
+            "    simulation = initialize!(model, output=output)"
+    )
 end
 
 function Base.show(io::IO, output::NetCDFOutput{F}) where {F}
@@ -143,18 +166,12 @@ function initialize!(
         output::NetCDFOutput,
         vars::Variables,
         model::AbstractModel,
+        callbacks::CALLBACK_DICT = CallbackDict(),
     )
     output.active || return nothing             # exit immediately for no output
 
-    # only checked for models that have a land component
-    if hasfield(typeof(model), :land) && !isnothing(model.land)
-        @assert get_nlayers(model.land) == size(output.field3Dland, 2) "$(size(output.field3Dland, 2))" *
-            " soil layers initialized for output, but $(get_nlayers(model.land)) soil layers initialized for model." *
-            " Please construct NetCDFOutput with the same `nlayers_soil` as the model."
-    end
-
     # SHARED INITIALIZATION (run folder, output frequency, counters, callbacks)
-    initialize!(output.core, output, model)
+    initialize!(output.core, output, model, callbacks)
 
     # CREATE NETCDF FILE, vector of NcVars for output
     (; run_path, filename) = output

--- a/SpeedyWeather/src/output/writers/output_writer_core.jl
+++ b/SpeedyWeather/src/output/writers/output_writer_core.jl
@@ -4,7 +4,7 @@ export OutputWriterCore
 and step/output counters. Embed as `core::OutputWriterCore` in every output writer.
 Option fields (path, id, overwrite, interval, …) stay as flat fields on the writer itself.
 
-Call `initialize!(core, output, model)` inside the writer's `initialize!` method to
+Call `initialize!(core, output, model, callbacks)` inside the writer's `initialize!` method to
 populate all derived fields from the writer's option fields and the model time step.
 Call `output!(core, output)` each time step to check if output should be written.
 Fields are $(TYPEDFIELDS)"""
@@ -49,12 +49,13 @@ end
 Initialize the `OutputWriterCore` from the option fields of `output` and `model`:
 determine the run folder (skipped for in-memory writers when `create_folder=false`),
 compute the output frequency from `model.time_stepping`, reset counters, and add
-standard callbacks (parameters txt, progress txt, restart file) if enabled.
-Returns `true` if output is active, `false` otherwise."""
+standard callbacks (parameters txt, progress txt, restart file) to `callbacks` if
+enabled. Returns `true` if output is active, `false` otherwise."""
 function initialize!(
         core::OutputWriterCore,
         output::AbstractOutput,
-        model::AbstractModel;
+        model::AbstractModel,
+        callbacks::CALLBACK_DICT;
         create_folder::Bool = true,
     )
     output.active || return false
@@ -78,10 +79,10 @@ function initialize!(
     core.timestep_counter = 0
     core.output_counter = 0
 
-    # CALLBACKS
-    output.write_parameters_txt && add!(model.callbacks, :parameters_txt => ParametersTxt())
-    output.write_progress_txt && add!(model.callbacks, :progress_txt => ProgressTxt())
-    output.write_restart && add!(model.callbacks, :variables_restart_file => WriteVariablesRestartFile())
+    # CALLBACKS: pre-fill the writer's run_path so callbacks know where to write
+    output.write_parameters_txt && add!(callbacks, :parameters_txt => ParametersTxt(path = output.run_path))
+    output.write_progress_txt && add!(callbacks, :progress_txt => ProgressTxt(path = output.run_path))
+    output.write_restart && add!(callbacks, :variables_restart_file => WriteVariablesRestartFile(path = output.run_path))
 
     return true
 end
@@ -98,10 +99,15 @@ end
 
 """$(TYPEDSIGNATURES)
 Reset the output frequency `interval` of `output` and re-initialize its `OutputWriterCore`
-so that the output frequency is recomputed from the model time step. If the requested 
+so that the output frequency is recomputed from the model time step. If the requested
 `interval` is not an integer multiple of the model time step, it is rounded to
 the nearest multiple."""
-function set!(output::AbstractOutput, model::AbstractModel; interval::Period)
+function set!(
+        output::AbstractOutput,
+        model::AbstractModel,
+        callbacks::CALLBACK_DICT = CallbackDict();
+        interval::Period,
+    )
     Δt_ms = model.time_stepping.Δt_millisec.value
     interval_ms = Millisecond(interval).value
     n = max(1, round(Int, interval_ms / Δt_ms))
@@ -111,6 +117,6 @@ function set!(output::AbstractOutput, model::AbstractModel; interval::Period)
             "Δt = $(Δt_ms)ms, rounding to $(rounded_ms)ms (= $(rounded_ms / 1000)s)."
     end
     output.interval = Second(round(Int, rounded_ms / 1000))
-    initialize!(output.core, output, model; create_folder = false)
+    initialize!(output.core, output, model, callbacks; create_folder = false)
     return nothing
 end

--- a/SpeedyWeather/src/output/writers/zarr_output.jl
+++ b/SpeedyWeather/src/output/writers/zarr_output.jl
@@ -8,7 +8,9 @@ extension and is only available once `Zarr.jl` is loaded:
 ```julia
 using Zarr
 using SpeedyWeather
-output = ZarrOutput(spectral_grid)
+model = PrimitiveWetModel(spectral_grid)
+output = ZarrOutput(model)
+simulation = initialize!(model, output=output)
 ```
 
 Type parameters: `Field2D`, `Field3D` are the scratch field types, `Interpolator`
@@ -101,7 +103,7 @@ end
 Stub constructor for [`ZarrOutput`](@ref). Errors with a helpful message until the
 `Zarr.jl` extension is loaded, at which point the extension installs the real
 constructor."""
-function ZarrOutput(SG::SpectralGrid, args...; kwargs...)
+function ZarrOutput(::AbstractModel, args...; kwargs...)
     Base.get_extension(@__MODULE__, :SpeedyWeatherZarrExt) === nothing && error(
         "ZarrOutput requires Zarr.jl to be loaded. Add `using Zarr` (or " *
             "`import Zarr`) before constructing a ZarrOutput."
@@ -109,7 +111,22 @@ function ZarrOutput(SG::SpectralGrid, args...; kwargs...)
     # When the extension is loaded its `ZarrOutput` method takes precedence and
     # this fallback is unreachable; the throw guards against being called via a
     # generic dispatch path before the extension has registered its method.
-    throw(MethodError(ZarrOutput, (SG, args...)))
+    throw(MethodError(ZarrOutput, (args...,)))
+end
+
+"""$(TYPEDSIGNATURES)
+Deprecated stub: the old `ZarrOutput(spectral_grid, ModelType)` constructor has
+been replaced by `ZarrOutput(model::AbstractModel)`. Construct the model first,
+then pass it to `ZarrOutput`."""
+function ZarrOutput(::SpectralGrid, args...; kwargs...)
+    error(
+        "`ZarrOutput(spectral_grid, ...)` has been removed. Construct the model " *
+            "first and call `ZarrOutput(model)` instead, e.g.\n" *
+            "    using Zarr\n" *
+            "    model = PrimitiveWetModel(spectral_grid)\n" *
+            "    output = ZarrOutput(model)\n" *
+            "    simulation = initialize!(model, output=output)"
+    )
 end
 
 function Base.show(io::IO, output::ZarrOutput{F}) where {F}

--- a/SpeedyWeather/src/time_stepping/leapfrog.jl
+++ b/SpeedyWeather/src/time_stepping/leapfrog.jl
@@ -61,13 +61,16 @@ function Leapfrog(spectral_grid::SpectralGrid; kwargs...)
 end
 
 """$(TYPEDSIGNATURES)
-Initialize leapfrogging `L` by recalculating the time step given the output
-`interval` from `model.output`. Recalculating will slightly adjust the time step to
-be a divisor such that an integer number of time steps matches exactly with the output
-interval."""
-function initialize!(L::Leapfrog, model::AbstractModel)
+Initialize leapfrogging `L` by recalculating the time step given an output `interval`.
+Recalculating will slightly adjust the time step to be a divisor such that an integer
+number of time steps matches exactly with the output interval. The `interval` defaults
+to `DEFAULT_OUTPUT_INTERVAL` (used when no output writers are attached to the simulation)."""
+function initialize!(
+        L::Leapfrog,
+        model::AbstractModel;
+        interval::Period = Second(DEFAULT_OUTPUT_INTERVAL),
+    )
     (; radius) = model.planet
-    interval = get_interval(model.output)
 
     # take radius from planet and recalculate time step and possibly adjust with output dt
     L.Δt_millisec = get_Δt_millisec(L.Δt_at_T31, L.trunc, radius, L.adjust_with_output, interval)
@@ -176,7 +179,8 @@ end
 """$(TYPEDSIGNATURES)
 First 1 or 2 time steps of `simulation`. If `model.time_stepping.start_with_euler` is true,
 then start with one Euler step with dt/2, followed by one Leapfrog step with dt.
-If false, continue with leapfrog steps at 2Δt (e.g. restart)."""
+If false, continue with leapfrog steps at 2Δt (e.g. restart). Pure time stepping only —
+output, callbacks and progress reporting are dispatched from [`time_stepping!`](@ref)."""
 function first_timesteps!(simulation::AbstractSimulation)
     (; variables, model) = simulation
     (; time_stepping) = model
@@ -194,8 +198,7 @@ function first_timesteps!(simulation::AbstractSimulation)
     end
 
     # only now initialise feedback for benchmark accuracy
-    (; clock) = variables.prognostic
-    initialize!(model.feedback, clock, model)
+    initialize!(simulation.feedback, simulation)
     return nothing
 end
 
@@ -236,9 +239,9 @@ function first_timesteps!(
     timestep!(clock, -Δt_millisec_half, increase_counter = false)
     timestep!(clock, Δt_millisec)
 
-    # do output and callbacks after the first proper (from i=0 to i=1) time step
-    callback!(model.callbacks, vars, model)
-    output!(model.output, Simulation(vars, model))
+    # output and callbacks for the first proper time step are dispatched by the
+    # caller `first_timesteps!(::AbstractSimulation)` which has access to the
+    # simulation-level callbacks/output writers
 
     # from now on precomputed implicit terms with 2Δt
     initialize!(implicit, 2Δt, vars, model)

--- a/SpeedyWeather/src/time_stepping/lorenz_ncycle.jl
+++ b/SpeedyWeather/src/time_stepping/lorenz_ncycle.jl
@@ -77,8 +77,11 @@ current_substep(L::NCycleLorenz, clock) = mod(clock.timestep_counter, L.cycles)
 
 """$(TYPEDSIGNATURES)
 Initialize NCycleLorenz time stepper."""
-function initialize!(L::NCycleLorenz, model::AbstractModel)
-    (; interval) = model.output
+function initialize!(
+        L::NCycleLorenz,
+        model::AbstractModel;
+        interval::Period = Second(DEFAULT_OUTPUT_INTERVAL),
+    )
     (; radius) = model.planet
 
     # Validate compatibility - runs ONCE, not every timestep

--- a/SpeedyWeather/src/time_stepping/time_integration.jl
+++ b/SpeedyWeather/src/time_stepping/time_integration.jl
@@ -75,9 +75,6 @@ function timestep!(
         lf1::Integer = 2,               # leapfrog index 1 (dis/enables Robert+Williams filter)
         lf2::Integer = 2,               # leapfrog index 2 (time step used for tendencies)
     )
-    # exit immediately if NaNs/Infs already present
-    (!isnothing(model.feedback) && model.feedback.nans_detected) && return nothing
-
     reset_tendencies!(vars)             # set the tendencies back to zero for accumulation
 
     # TENDENCIES, DIFFUSION, LEAPFROGGING AND TRANSFORM SPECTRAL STATE TO GRID
@@ -103,8 +100,6 @@ function timestep!(
         lf1::Integer = 2,               # leapfrog index 1 (dis/enables Robert+Williams filter)
         lf2::Integer = 2,               # leapfrog index 2 (time step used for tendencies)
     )
-    # exit immediately if NaNs/Infs already present
-    (!isnothing(model.feedback) && model.feedback.nans_detected) && return nothing
     reset_tendencies!(vars)             # set the tendencies back to zero for accumulation
 
     # GET TENDENCIES, CORRECT THEM FOR SEMI-IMPLICIT INTEGRATION
@@ -133,8 +128,6 @@ function timestep!(
         lf1::Integer = 2,               # leapfrog index 1 (dis/enables Robert+Williams filter)
         lf2::Integer = 2,               # leapfrog index 2 (time step used for tendencies)
     )
-    # exit immediately if NaNs/Infs already present
-    (!isnothing(model.feedback) && model.feedback.nans_detected) && return nothing
     reset_tendencies!(vars)             # set the tendencies back to zero for accumulation
 
     if ~model.dynamics_only             # switch on/off all physics parameterizations
@@ -165,8 +158,10 @@ function timestep!(
 end
 
 """$(TYPEDSIGNATURES)
-Perform one single time step of `simulation` including
-possibly output and callbacks."""
+Advance the prognostic state of `simulation` by one model time step. Routes to
+`first_timesteps!` on the very first call (Euler+leapfrog warm-up) and to
+`later_timestep!` afterwards. Output, callbacks and the progress meter are dispatched
+from [`time_stepping!`](@ref), not here."""
 function timestep!(simulation::AbstractSimulation)
     (; clock) = simulation.variables.prognostic
     @trace if clock.timestep_counter == 0
@@ -179,28 +174,43 @@ function timestep!(simulation::AbstractSimulation)
 end
 
 """$(TYPEDSIGNATURES)
-Perform one single "normal" time step of `simulation`, after `first_timesteps!`."""
+Perform one single "normal" time step of `simulation`, after `first_timesteps!`. Pure
+time stepping only — output, callbacks and progress reporting are dispatched from
+[`time_stepping!`](@ref)."""
 function later_timestep!(simulation::AbstractSimulation)
     (; variables, model) = simulation
-    (; feedback, output) = model
     (; Δt, Δt_millisec) = model.time_stepping
     (; clock) = variables.prognostic
 
     timestep!(variables, 2Δt, model)                # calculate tendencies and leapfrog forward
     timestep!(clock, Δt_millisec)                   # time of lf=2 and variables after timestep!
-
-    progress!(feedback, variables)                  # updates the progress meter bar
-    output!(output, simulation)                     # do output?
-    callback!(model.callbacks, variables, model)    # any callbacks?
     return nothing
 end
 
 """$(TYPEDSIGNATURES)
-Main time loop that loops over all time steps."""
+Main time loop that loops over all time steps and dispatches output, callbacks and the
+progress meter from a single place. `timestep!(simulation)` itself only advances the
+prognostic state; everything else lives here."""
 function time_stepping!(simulation::AbstractSimulation)
     (; clock) = simulation.variables.prognostic
+    (; feedback, callbacks) = simulation
     for _ in 1:clock.n_timesteps        # MAIN LOOP
+        # exit immediately if NaNs/Infs were detected on the previous iteration
+        feedback.nans_detected && break
+
+        # advance the prognostic state (Euler+leapfrog on the very first iteration via
+        # first_timesteps!, plain leapfrog Δt afterwards via later_timestep!)
         timestep!(simulation)
+
+        # progress meter is initialized inside first_timesteps! to exclude compilation
+        # time, so we only start reporting from the second main-loop iteration onward
+        clock.timestep_counter > 1 && progress!(feedback, simulation.variables)
+
+        # all output writers and callbacks fire after the time step
+        for writer in simulation.output
+            output!(writer, simulation)
+        end
+        callback!(callbacks, simulation)
     end
     return simulation
 end

--- a/SpeedyWeather/test/GPU/barotropic.jl
+++ b/SpeedyWeather/test/GPU/barotropic.jl
@@ -6,7 +6,7 @@ using JLD2
     simulation = initialize!(model)
     run!(simulation, steps = 4)
 
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
 end
 
 @testset "GPU Barotropic with JLD2Output" begin
@@ -17,7 +17,7 @@ end
     simulation = initialize!(model)
     run!(simulation, steps = 3, output = true)
 
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
 
     # JLD2Output should have transferred data to CPU before writing
     f = jldopen(joinpath(output.run_path, output.filename), "r")
@@ -37,7 +37,7 @@ end
     simulation = initialize!(model)
     run!(simulation, steps = 3, output = true)
 
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
 
     # check IC snapshot (transfer to CPU first to avoid scalar indexing on GPU)
     ic = output.output[1].prognostic

--- a/SpeedyWeather/test/GPU/primitive_wet.jl
+++ b/SpeedyWeather/test/GPU/primitive_wet.jl
@@ -10,6 +10,6 @@
     simulation = initialize!(model)
     run!(simulation, steps = 3, output = true)
 
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
     @test isfile(joinpath(output.run_path, output.filename))
 end

--- a/SpeedyWeather/test/GPU/shallowwater.jl
+++ b/SpeedyWeather/test/GPU/shallowwater.jl
@@ -4,5 +4,5 @@
     simulation = initialize!(model)
     run!(simulation, steps = 4)
 
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
 end

--- a/SpeedyWeather/test/dynamics/default_barotropic.jl
+++ b/SpeedyWeather/test/dynamics/default_barotropic.jl
@@ -3,5 +3,5 @@
     model = BarotropicModel(spectral_grid)
     simulation = initialize!(model)
     run!(simulation, period = Year(1))
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
 end

--- a/SpeedyWeather/test/dynamics/default_primitive_dry.jl
+++ b/SpeedyWeather/test/dynamics/default_primitive_dry.jl
@@ -3,5 +3,5 @@
     model = PrimitiveDryModel(spectral_grid)
     simulation = initialize!(model)
     run!(simulation, period = Year(1))
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
 end

--- a/SpeedyWeather/test/dynamics/default_primitive_wet.jl
+++ b/SpeedyWeather/test/dynamics/default_primitive_wet.jl
@@ -3,5 +3,5 @@
     model = PrimitiveWetModel(spectral_grid)
     simulation = initialize!(model)
     run!(simulation, period = Year(1))
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
 end

--- a/SpeedyWeather/test/dynamics/default_shallowwater.jl
+++ b/SpeedyWeather/test/dynamics/default_shallowwater.jl
@@ -3,5 +3,5 @@
     model = ShallowWaterModel(spectral_grid)
     simulation = initialize!(model)
     run!(simulation, period = Year(1))
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
 end

--- a/SpeedyWeather/test/dynamics/forcing_drag.jl
+++ b/SpeedyWeather/test/dynamics/forcing_drag.jl
@@ -15,7 +15,7 @@
         simulation = initialize!(model)
 
         run!(simulation, period = Day(15), output = true)
-        @test simulation.model.feedback.nans_detected == false
+        @test simulation.feedback.nans_detected == false
     end
 end
 
@@ -36,6 +36,6 @@ end
         simulation = initialize!(model)
 
         run!(simulation, period = Day(15), output = true)
-        @test simulation.model.feedback.nans_detected == false
+        @test simulation.feedback.nans_detected == false
     end
 end

--- a/SpeedyWeather/test/dynamics/matrix_transform.jl
+++ b/SpeedyWeather/test/dynamics/matrix_transform.jl
@@ -4,5 +4,5 @@
     model = PrimitiveWetModel(spectral_grid; spectral_transform)
     simulation = initialize!(model)
     run!(simulation, period = Day(20))
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
 end

--- a/SpeedyWeather/test/dynamics/particle_advection.jl
+++ b/SpeedyWeather/test/dynamics/particle_advection.jl
@@ -18,9 +18,9 @@
         model = Model(spectral_grid; particle_advection)
 
         tmp_tracker_path = mktempdir(pwd(), prefix = "tmp_tracker_")  # Cleaned up when the process exits
-        add!(model.callbacks, ParticleTracker(spectral_grid, path = tmp_tracker_path, filename = "particles.nc"))
+        callbacks = CallbackDict(:particle_tracker => ParticleTracker(spectral_grid, path = tmp_tracker_path, filename = "particles.nc"))
 
-        simulation = initialize!(model)
+        simulation = initialize!(model; callbacks)
         run!(simulation, period = Day(1))
 
         for particle in simulation.variables.prognostic.particles

--- a/SpeedyWeather/test/dynamics/vertical_advection.jl
+++ b/SpeedyWeather/test/dynamics/vertical_advection.jl
@@ -32,6 +32,6 @@ end
         )
         simulation = initialize!(model)
         run!(simulation, period = Day(1))
-        @test simulation.model.feedback.nans_detected == false
+        @test simulation.feedback.nans_detected == false
     end
 end

--- a/SpeedyWeather/test/output/callbacks.jl
+++ b/SpeedyWeather/test/output/callbacks.jl
@@ -31,9 +31,9 @@ end
 
     function SpeedyWeather.initialize!(
             callback::StormChaser,
-            vars::Variables,
-            model::AbstractModel,
+            simulation::SpeedyWeather.AbstractSimulation,
         )
+        vars, model = simulation.variables, simulation.model
         # allocate recorder: number of time steps (incl initial conditions) in simulation
         callback.maximum_surface_wind_speed = zeros(vars.prognostic.clock.n_timesteps + 1)
 
@@ -60,9 +60,9 @@ end
 
     function SpeedyWeather.callback!(
             callback::StormChaser,
-            vars::Variables,
-            model::AbstractModel,
+            simulation::SpeedyWeather.AbstractSimulation,
         )
+        vars, model = simulation.variables, simulation.model
 
         # increase counter
         callback.timestep_counter += 1
@@ -81,20 +81,20 @@ end
 
     spectral_grid = SpectralGrid()
     callbacks = CallbackDict(NoCallback())
-    model = PrimitiveWetModel(spectral_grid; callbacks)
+    model = PrimitiveWetModel(spectral_grid)
 
     storm_chaser = StormChaser(spectral_grid)
     key = :storm_chaser
-    add!(model.callbacks, key => storm_chaser)      # with :storm_chaser key
-    add!(model.callbacks, NoCallback())             # add dummy too
-    add!(model, NoCallback())                       # add dummy with ::AbstractModel interface
+    add!(callbacks, key => storm_chaser)            # with :storm_chaser key
+    add!(callbacks, NoCallback())                   # add dummy too
 
-    simulation = initialize!(model)
+    simulation = initialize!(model; callbacks)
+    add!(simulation, NoCallback())                  # add dummy with ::AbstractSimulation interface
     run!(simulation, period = Day(1))
 
     # maximum wind speed should always be non-negative
-    @test all(model.callbacks[key].maximum_surface_wind_speed .>= 0)
+    @test all(simulation.callbacks[key].maximum_surface_wind_speed .>= 0)
 
     # highest wind speed across all time steps should be positive
-    @test maximum(model.callbacks[key].maximum_surface_wind_speed) > 0
+    @test maximum(simulation.callbacks[key].maximum_surface_wind_speed) > 0
 end

--- a/SpeedyWeather/test/output/netcdf_output.jl
+++ b/SpeedyWeather/test/output/netcdf_output.jl
@@ -6,14 +6,14 @@ using NCDatasets, Dates
 
     for Grid in (FullGaussianGrid, FullClenshawGrid, OctahedralGaussianGrid, OctahedralClenshawGrid, HEALPixGrid, OctaHEALPixGrid)
         spectral_grid = SpectralGrid(nlayers = 1)
-        output = NetCDFOutput(spectral_grid, path = tmp_output_path)
-        model = BarotropicModel(spectral_grid; output)
-        simulation = initialize!(model)
+        model = BarotropicModel(spectral_grid)
+        output = NetCDFOutput(model, path = tmp_output_path)
+        simulation = initialize!(model; output)
         run!(simulation, output = true; period)
-        @test simulation.model.feedback.nans_detected == false
+        @test simulation.feedback.nans_detected == false
 
         # read netcdf file and check that all variables exist
-        ds = NCDataset(joinpath(model.output.run_path, model.output.filename))
+        ds = NCDataset(joinpath(output.run_path, output.filename))
         for key in keys(output.variables)
             @test haskey(ds, key)
 
@@ -32,14 +32,14 @@ end
 
     for output_NF in (Float32, Float64)
         spectral_grid = SpectralGrid(nlayers = 1)
-        output = NetCDFOutput(spectral_grid, ShallowWater, path = tmp_output_path; output_NF)
-        model = ShallowWaterModel(spectral_grid; output)
-        simulation = initialize!(model)
+        model = ShallowWaterModel(spectral_grid)
+        output = NetCDFOutput(model, path = tmp_output_path; output_NF)
+        simulation = initialize!(model; output)
         run!(simulation, output = true; period)
-        @test simulation.model.feedback.nans_detected == false
+        @test simulation.feedback.nans_detected == false
 
         # read netcdf file and check that all variables exist
-        ds = NCDataset(joinpath(model.output.run_path, model.output.filename))
+        ds = NCDataset(joinpath(output.run_path, output.filename))
         for key in keys(output.variables)
             @test haskey(ds, key)
 
@@ -51,14 +51,14 @@ end
         div_output = SpeedyWeather.DivergenceOutput()
         add!(output.variables, div_output)
         run!(simulation, output = true; period)
-        ds = NCDataset(joinpath(model.output.run_path, model.output.filename))
+        ds = NCDataset(joinpath(output.run_path, output.filename))
         @test haskey(ds, div_output.name)
 
         # add orography output
         orog_output = SpeedyWeather.OrographyOutput()
         add!(output.variables, orog_output)
         run!(simulation, output = true; period)
-        ds = NCDataset(joinpath(model.output.run_path, model.output.filename))
+        ds = NCDataset(joinpath(output.run_path, output.filename))
         @test haskey(ds, orog_output.name)
 
         nx, ny = size(ds[orog_output.name])
@@ -67,7 +67,7 @@ end
         # delete divergence output
         delete!(output, div_output.name)
         run!(simulation, output = true; period)
-        ds = NCDataset(joinpath(model.output.run_path, model.output.filename))
+        ds = NCDataset(joinpath(output.run_path, output.filename))
         @test ~haskey(ds, div_output.name)
     end
 end
@@ -80,14 +80,14 @@ end
     for nlat_half in (24, 32, 48, 64)
         spectral_grid = SpectralGrid(nlayers = 8)
         output_grid = RingGrids.full_grid_type(typeof(spectral_grid.grid))(nlat_half)
-        output = NetCDFOutput(spectral_grid, ShallowWater, path = tmp_output_path; output_grid)
-        model = PrimitiveDryModel(spectral_grid; output)
-        simulation = initialize!(model)
+        model = PrimitiveDryModel(spectral_grid)
+        output = NetCDFOutput(model, path = tmp_output_path; output_grid)
+        simulation = initialize!(model; output)
         run!(simulation, output = true; period)
-        @test simulation.model.feedback.nans_detected == false
+        @test simulation.feedback.nans_detected == false
 
         # read netcdf file and check that all variables exist
-        ds = NCDataset(joinpath(model.output.run_path, model.output.filename))
+        ds = NCDataset(joinpath(output.run_path, output.filename))
         for key in keys(output.variables)
             @test haskey(ds, key)
         end
@@ -105,14 +105,14 @@ end
     # test also output at various resolutions
     spectral_grid = SpectralGrid(nlayers = 8)
     for interval in (Hour(1), Minute(120), Hour(3), Hour(6), Day(1))
-        output = NetCDFOutput(spectral_grid, PrimitiveWet, path = tmp_output_path; interval)
-        model = PrimitiveWetModel(spectral_grid; output)
-        simulation = initialize!(model)
+        model = PrimitiveWetModel(spectral_grid)
+        output = NetCDFOutput(model, path = tmp_output_path; interval)
+        simulation = initialize!(model; output)
         run!(simulation, output = true; period)
-        @test simulation.model.feedback.nans_detected == false
+        @test simulation.feedback.nans_detected == false
 
         # read netcdf file and check that all variables exist
-        ds = NCDataset(joinpath(model.output.run_path, model.output.filename))
+        ds = NCDataset(joinpath(output.run_path, output.filename))
         for key in keys(output.variables)
             @test haskey(ds, key)
 
@@ -123,12 +123,12 @@ end
     end
 
     # test outputting other model defaults
-    output = NetCDFOutput(spectral_grid, PrimitiveWet, path = tmp_output_path)
-    model = PrimitiveWetModel(spectral_grid; output)
+    model = PrimitiveWetModel(spectral_grid)
+    output = NetCDFOutput(model, path = tmp_output_path)
 
     # Add surface variables output for testing them
     add!(
-        model,
+        output,
         SpeedyWeather.ZonalVelocity10mOutput(),
         SpeedyWeather.MeridionalVelocity10mOutput(),
         SpeedyWeather.SurfaceTemperatureOutput(),
@@ -136,11 +136,11 @@ end
         #         SpeedyWeather.SurfacePressureOutput(),        # don't output surface pressure too
     )
 
-    simulation = initialize!(model)
+    simulation = initialize!(model; output)
     run!(simulation, output = true; period)
 
-    @test simulation.model.feedback.nans_detected == false
-    ds = NCDataset(joinpath(model.output.run_path, model.output.filename))
+    @test simulation.feedback.nans_detected == false
+    ds = NCDataset(joinpath(output.run_path, output.filename))
 
     # test
     @test haskey(ds, "temp")
@@ -175,9 +175,9 @@ end
     tmp_output_path = mktempdir(pwd(), prefix = "tmp_testruns_")  # Cleaned up when the process exits
 
     spectral_grid = SpectralGrid()
-    output = NetCDFOutput(spectral_grid, PrimitiveDry, path = tmp_output_path, id = "restart-test")
-    model = PrimitiveDryModel(spectral_grid; output)
-    simulation = initialize!(model)
+    model = PrimitiveDryModel(spectral_grid)
+    output = NetCDFOutput(model, path = tmp_output_path, id = "restart-test")
+    simulation = initialize!(model; output)
     run!(simulation, output = true; period = Day(1))
 
     initial_conditions = StartFromFile(path = tmp_output_path, id = "restart-test")
@@ -199,8 +199,10 @@ end
 
     spectral_grid = SpectralGrid()
     model = PrimitiveDryModel(spectral_grid)
-    simulation = initialize!(model)
-    add!(model, :restart_file => WriteVariablesRestartFile(path = tmp_output_path, write_only_with_output = false, filename = "myrestart.jld2"))
+    callbacks = SpeedyWeather.CallbackDict(
+        :restart_file => WriteVariablesRestartFile(path = tmp_output_path, filename = "myrestart.jld2"),
+    )
+    simulation = initialize!(model; callbacks)
     run!(simulation, period = Day(1))
 
     initial_conditions = StartFromFile(run_folder = tmp_output_path, filename = "myrestart.jld2")
@@ -230,44 +232,48 @@ end
     tmp_output_path = mktempdir(pwd(), prefix = "tmp_testruns_")  # Cleaned up when the process exits
 
     spectral_grid = SpectralGrid()
-    output = NetCDFOutput(spectral_grid, PrimitiveDry, path = tmp_output_path, id = "dense-output-test", interval = Hour(0))
-    model = PrimitiveDryModel(spectral_grid; output)
-    simulation = initialize!(model)
+    model = PrimitiveDryModel(spectral_grid)
+    output = NetCDFOutput(model, path = tmp_output_path, id = "dense-output-test", interval = Hour(0))
+    simulation = initialize!(model; output)
     run!(simulation, output = true; period = Day(1))
 
     progn = simulation.variables.prognostic
-    tmp_read_path = joinpath(model.output.run_path, model.output.filename)
+    tmp_read_path = joinpath(output.run_path, output.filename)
     t = NCDataset(tmp_read_path)["time"][:]
-    @test t == manual_time_axis(model.output.startdate, model.time_stepping.Δt_millisec, progn.clock.n_timesteps)
+    @test t == manual_time_axis(output.startdate, model.time_stepping.Δt_millisec, progn.clock.n_timesteps)
 
     # do a simulation with the adjust_Δt_with_output turned on
-    output = NetCDFOutput(spectral_grid, PrimitiveDry, path = tmp_output_path, id = "adjust_dt_with_output-test", interval = Minute(70))
     time_stepping = Leapfrog(spectral_grid, adjust_with_output = true)
-    model = PrimitiveDryModel(spectral_grid; output, time_stepping)
-    simulation = initialize!(model)
+    model = PrimitiveDryModel(spectral_grid; time_stepping)
+    output = NetCDFOutput(model, path = tmp_output_path, id = "adjust_dt_with_output-test", interval = Minute(70))
+    simulation = initialize!(model; output)
     run!(simulation, output = true; period = Day(1))
-    t = SpeedyWeather.load_trajectory("time", model)
+    t = SpeedyWeather.load_trajectory("time", simulation)
     @test all(y -> y == diff(t)[1], diff(t)) # all elements equal
     @test diff(t)[1] == Millisecond(Minute(70))
 
     # this is a nonsense simulation with way too large timesteps, but it's here to test the time axis output
     # for future tests: This simulation blows up because of too large time steps but only a warning is thrown
-    # at the moment, no error
+    # at the moment, no error. With the refactored simulation/output split, `later_timestep!`
+    # short-circuits once NaNs are detected so output also stops at that point — so the written
+    # time axis is a prefix of the full requested axis, not the full one.
     # 1kyrs simulation
     spectral_grid = SpectralGrid()
     time_stepping = Leapfrog(spectral_grid, Δt_at_T31 = Day(3650))
-    output = NetCDFOutput(spectral_grid, PrimitiveDry, path = tmp_output_path, id = "long-output-test", interval = Day(3650))
-    model = PrimitiveDryModel(spectral_grid; output, time_stepping)
-    simulation = initialize!(model)
+    model = PrimitiveDryModel(spectral_grid; time_stepping)
+    output = NetCDFOutput(model, path = tmp_output_path, id = "long-output-test", interval = Day(3650))
+    simulation = initialize!(model; output)
     model.implicit.initialized = true     # bypass implicit initialization with this insanely large timestep (threw SingularException)
     model.implicit.reinitialize = false
     run!(simulation, output = true, period = Day(365000))
 
     progn = simulation.variables.prognostic
-    tmp_read_path = joinpath(model.output.run_path, model.output.filename)
+    tmp_read_path = joinpath(output.run_path, output.filename)
     t = NCDataset(tmp_read_path)["time"][:]
-    @test t == manual_time_axis(model.output.startdate, model.time_stepping.Δt_millisec, progn.clock.n_timesteps)
-    @test t == SpeedyWeather.load_trajectory("time", model)
+    expected_full = manual_time_axis(output.startdate, model.time_stepping.Δt_millisec, progn.clock.n_timesteps)
+    # what we got is a prefix of the full requested time axis
+    @test t == expected_full[1:length(t)]
+    @test t == SpeedyWeather.load_trajectory("time", simulation)
 end
 
 @testset "get_output_path" begin
@@ -280,11 +286,11 @@ end
     @test_throws ErrorException SpeedyWeather.get_output_path(simulation)
 
     # output active: should return the correct path
-    output = NetCDFOutput(spectral_grid, path = tmp_output_path)
-    model = BarotropicModel(spectral_grid; output)
-    simulation = initialize!(model)
+    model = BarotropicModel(spectral_grid)
+    output = NetCDFOutput(model, path = tmp_output_path)
+    simulation = initialize!(model; output)
     run!(simulation, output = true, period = Day(1))
-    expected_path = joinpath(simulation.model.output.run_path, simulation.model.output.filename)
+    expected_path = joinpath(output.run_path, output.filename)
     @test SpeedyWeather.get_output_path(simulation) == expected_path
     @test isfile(SpeedyWeather.get_output_path(simulation))
 end
@@ -293,9 +299,9 @@ end
     tmp_output_path = mktempdir(pwd(), prefix = "tmp_testruns_")
 
     spectral_grid = SpectralGrid(nlayers = 1)
-    output = NetCDFOutput(spectral_grid, path = tmp_output_path, interval = Hour(6))
-    model = BarotropicModel(spectral_grid; output)
-    simulation = initialize!(model)
+    model = BarotropicModel(spectral_grid)
+    output = NetCDFOutput(model, path = tmp_output_path, interval = Hour(6))
+    simulation = initialize!(model; output)
     run!(simulation, output = true, period = Day(1))
 
     Δt_ms = model.time_stepping.Δt_millisec.value
@@ -303,33 +309,33 @@ end
     # change interval to a clean multiple of the model time step (no rounding)
     new_interval_ms = 4 * Δt_ms
     new_interval = Millisecond(new_interval_ms)
-    @test_logs set!(model.output, model; interval = new_interval)   # no @info log
-    @test model.output.core.output_every_n_steps == 4
-    @test Millisecond(model.output.interval).value == new_interval_ms
+    @test_logs set!(output, model, simulation.callbacks; interval = new_interval)   # no @info log
+    @test output.core.output_every_n_steps == 4
+    @test Millisecond(output.interval).value == new_interval_ms
 
     # counters reset by re-initialization
-    @test model.output.core.timestep_counter == 0
-    @test model.output.core.output_counter == 0
+    @test output.core.timestep_counter == 0
+    @test output.core.output_counter == 0
 
     # change to a different multiple
-    set!(model.output, model; interval = Millisecond(2 * Δt_ms))
-    @test model.output.core.output_every_n_steps == 2
-    @test Millisecond(model.output.interval).value == 2 * Δt_ms
+    set!(output, model, simulation.callbacks; interval = Millisecond(2 * Δt_ms))
+    @test output.core.output_every_n_steps == 2
+    @test Millisecond(output.interval).value == 2 * Δt_ms
 
     # request an interval that is NOT a multiple of the model time step:
     # use Δt + 1ms to force rounding back to a single time step (and an @info)
     non_multiple = Millisecond(Δt_ms + 1)
-    @test_logs (:info,) set!(model.output, model; interval = non_multiple)
-    @test model.output.core.output_every_n_steps == 1
-    @test Millisecond(model.output.interval).value == Δt_ms
+    @test_logs (:info,) set!(output, model, simulation.callbacks; interval = non_multiple)
+    @test output.core.output_every_n_steps == 1
+    @test Millisecond(output.interval).value == Δt_ms
 
     # check that run! after set! uses the new output frequency
     period = Day(1)
-    set!(model.output, model; interval = Hour(2))   # = 3 * Δt at default settings
+    set!(output, model, simulation.callbacks; interval = Hour(2))   # = 3 * Δt at default settings
     expected_n = round(Int, Millisecond(Hour(2)).value / Δt_ms)
-    @test model.output.core.output_every_n_steps == expected_n
+    @test output.core.output_every_n_steps == expected_n
     run!(simulation, output = true; period)
-    ds = NCDataset(joinpath(model.output.run_path, model.output.filename))
+    ds = NCDataset(joinpath(output.run_path, output.filename))
     nt = size(ds["vor"])[end]
-    @test nt == Int(Millisecond(period).value ÷ Millisecond(model.output.interval).value) + 1
+    @test nt == Int(Millisecond(period).value ÷ Millisecond(output.interval).value) + 1
 end

--- a/SpeedyWeather/test/output/zarr_output.jl
+++ b/SpeedyWeather/test/output/zarr_output.jl
@@ -2,7 +2,8 @@ using Zarr, Dates
 
 @testset "ZarrOutput type and defaults" begin
     spectral_grid = SpectralGrid(trunc = 5, nlayers = 1)
-    output = ZarrOutput(spectral_grid)
+    model = BarotropicModel(spectral_grid)
+    output = ZarrOutput(model)
     @test output isa SpeedyWeather.ZarrOutput
     @test output.active == false
     @test output.filename == "output.zarr"
@@ -13,16 +14,16 @@ end
     period = Day(1)
 
     spectral_grid = SpectralGrid(trunc = 5, nlayers = 1)
+    model = ShallowWaterModel(spectral_grid)
     output = ZarrOutput(
-        spectral_grid, ShallowWater;
+        model;
         path = tmp_output_path, write_restart = false,
     )
-    model = ShallowWaterModel(spectral_grid; output)
-    simulation = initialize!(model)
+    simulation = initialize!(model; output)
     run!(simulation, output = true; period)
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
 
-    g = Zarr.zopen(joinpath(model.output.run_path, model.output.filename))
+    g = Zarr.zopen(joinpath(output.run_path, output.filename))
 
     # all declared output variables made it into the store
     for var in values(output.variables)
@@ -54,16 +55,16 @@ end
     period = Day(1)
 
     spectral_grid = SpectralGrid(trunc = 5, nlayers = 4)
+    model = PrimitiveWetModel(spectral_grid)
     output = ZarrOutput(
-        spectral_grid, PrimitiveWet;
+        model;
         path = tmp_output_path, write_restart = false,
     )
-    model = PrimitiveWetModel(spectral_grid; output)
-    simulation = initialize!(model)
+    simulation = initialize!(model; output)
     run!(simulation, output = true; period)
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
 
-    g = Zarr.zopen(joinpath(model.output.run_path, model.output.filename))
+    g = Zarr.zopen(joinpath(output.run_path, output.filename))
     @test haskey(g.arrays, "temp")
     @test haskey(g.arrays, "humid")
     @test haskey(g.arrays, "soil_layer")    # soil dim coordinate
@@ -90,8 +91,9 @@ end
     period = Day(1)
 
     spectral_grid = SpectralGrid(trunc = 5, nlayers = 4)
+    model = PrimitiveWetModel(spectral_grid)
     output = ZarrOutput(
-        spectral_grid, PrimitiveWet;
+        model;
         path = tmp_output_path, write_restart = false,
     )
     add!(
@@ -100,12 +102,11 @@ end
         SpeedyWeather.ZonalVelocity10mOutput(),
         SpeedyWeather.MeridionalVelocity10mOutput(),
     )
-    model = PrimitiveWetModel(spectral_grid; output)
-    simulation = initialize!(model)
+    simulation = initialize!(model; output)
     run!(simulation, output = true; period)
-    @test simulation.model.feedback.nans_detected == false
+    @test simulation.feedback.nans_detected == false
 
-    g = Zarr.zopen(joinpath(model.output.run_path, model.output.filename))
+    g = Zarr.zopen(joinpath(output.run_path, output.filename))
     nx, ny = RingGrids.matrix_size(output.field2D)
     nt = Int(period / output.interval) + 1
 
@@ -121,8 +122,9 @@ end
     period = Day(1)
 
     spectral_grid = SpectralGrid(trunc = 5, nlayers = 1)
+    model = ShallowWaterModel(spectral_grid)
     output = ZarrOutput(
-        spectral_grid, ShallowWater;
+        model;
         path = tmp_output_path, write_restart = false,
     )
 
@@ -131,10 +133,9 @@ end
     add!(output, div_output)
     @test haskey(output.variables, Symbol(div_output.name))
 
-    model = ShallowWaterModel(spectral_grid; output)
-    simulation = initialize!(model)
+    simulation = initialize!(model; output)
     run!(simulation, output = true; period)
-    g = Zarr.zopen(joinpath(model.output.run_path, model.output.filename))
+    g = Zarr.zopen(joinpath(output.run_path, output.filename))
     @test haskey(g.arrays, div_output.name)
 
     # delete!: variable is removed from the dict (Zarr arrays from the previous
@@ -152,15 +153,15 @@ end
     period = Day(1)
 
     spectral_grid = SpectralGrid(trunc = 5, nlayers = 1)
+    model = ShallowWaterModel(spectral_grid)
     output = ZarrOutput(
-        spectral_grid, ShallowWater;
+        model;
         path = tmp_output_path, write_restart = false,
     )
-    model = ShallowWaterModel(spectral_grid; output)
-    simulation = initialize!(model)
+    simulation = initialize!(model; output)
     run!(simulation, output = true; period)
 
-    g = Zarr.zopen(joinpath(model.output.run_path, model.output.filename))
+    g = Zarr.zopen(joinpath(output.run_path, output.filename))
 
     # 4D variable: shape (time, layer, lat, lon) on disk and dims
     # attribute in matching order
@@ -186,18 +187,18 @@ end
     period = Day(1)
 
     spectral_grid = SpectralGrid(trunc = 5, nlayers = 1)
+    model = ShallowWaterModel(spectral_grid)
     output = ZarrOutput(
-        spectral_grid, ShallowWater;
+        model;
         path = tmp_output_path,
         write_restart = false,
         time_chunk = 3,
         compressor = Zarr.BloscCompressor(clevel = 5),
     )
-    model = ShallowWaterModel(spectral_grid; output)
-    simulation = initialize!(model)
+    simulation = initialize!(model; output)
     run!(simulation, output = true; period)
 
-    g = Zarr.zopen(joinpath(model.output.run_path, model.output.filename))
+    g = Zarr.zopen(joinpath(output.run_path, output.filename))
     z_vor = g["vor"]
     # chunk along the time axis matches `time_chunk`
     @test z_vor.metadata.chunks[end] == 3
@@ -210,16 +211,16 @@ end
     period = Day(1)
 
     spectral_grid = SpectralGrid(trunc = 5, nlayers = 4)
+    model = PrimitiveDryModel(spectral_grid)
     output = ZarrOutput(
-        spectral_grid, PrimitiveDry;
+        model;
         path = tmp_output_path, write_restart = false,
         lon_chunk = 4, lat_chunk = 4, vertical_chunk = 2,
     )
-    model = PrimitiveDryModel(spectral_grid; output)
-    simulation = initialize!(model)
+    simulation = initialize!(model; output)
     run!(simulation, output = true; period)
 
-    g = Zarr.zopen(joinpath(model.output.run_path, model.output.filename))
+    g = Zarr.zopen(joinpath(output.run_path, output.filename))
 
     # 4D variable: chunks come back in Julia (column-major) order: (lon, lat, layer, time)
     z_temp = g["temp"]
@@ -246,16 +247,16 @@ end
     period = Day(1)
 
     spectral_grid = SpectralGrid(trunc = 5, nlayers = 1)
+    model = ShallowWaterModel(spectral_grid)
     output = ZarrOutput(
-        spectral_grid, ShallowWater;
+        model;
         path = tmp_output_path, write_restart = false,
         lon_chunk = 100_000, lat_chunk = 100_000, vertical_chunk = 100_000,
     )
-    model = ShallowWaterModel(spectral_grid; output)
-    simulation = initialize!(model)
+    simulation = initialize!(model; output)
     run!(simulation, output = true; period)
 
-    g = Zarr.zopen(joinpath(model.output.run_path, model.output.filename))
+    g = Zarr.zopen(joinpath(output.run_path, output.filename))
     z_vor = g["vor"]
     nlon, nlat = RingGrids.matrix_size(output.field2D)
     @test z_vor.metadata.chunks[1] == nlon
@@ -268,19 +269,19 @@ end
     period = Day(1)
 
     spectral_grid = SpectralGrid(trunc = 5, nlayers = 1)
+    model = ShallowWaterModel(spectral_grid)
     output = ZarrOutput(
-        spectral_grid, ShallowWater;
+        model;
         path = tmp_output_path, write_restart = false, id = "rerun",
     )
-    model = ShallowWaterModel(spectral_grid; output)
-    simulation = initialize!(model)
+    simulation = initialize!(model; output)
 
     run!(simulation, output = true; period)
-    first_path = model.output.run_path
+    first_path = output.run_path
     n_first = length(Zarr.zopen(joinpath(first_path, output.filename))["time"][:])
 
     run!(simulation, output = true; period)
-    second_path = model.output.run_path
+    second_path = output.run_path
 
     # paths differ (new run folder) and the old store wasn't grown by the
     # second run

--- a/SpeedyWeather/test/parameterizations/convection.jl
+++ b/SpeedyWeather/test/parameterizations/convection.jl
@@ -18,8 +18,7 @@
             if ~(Convection == BettsMillerConvection && Model == PrimitiveDryModel)
                 convection = Convection(spectral_grid)
                 model = Model(spectral_grid; convection)
-                model.feedback.verbose = false
-                simulation = initialize!(model)
+                simulation = initialize!(model; feedback = Feedback(verbose = false))
 
                 run!(simulation, steps = 36)
             end

--- a/SpeedyWeather/test/parameterizations/land_sea_mask.jl
+++ b/SpeedyWeather/test/parameterizations/land_sea_mask.jl
@@ -3,9 +3,8 @@
         spectral_grid = SpectralGrid(trunc = 31, nlayers = 8)
         mask = Mask(spectral_grid)
         model = PrimitiveWetModel(spectral_grid; land_sea_mask = mask)
-        simulation = initialize!(model)
-        model.feedback.verbose = false
+        simulation = initialize!(model; feedback = Feedback(verbose = false))
         run!(simulation, period = Day(5))
-        @test simulation.model.feedback.nans_detected == false
+        @test simulation.feedback.nans_detected == false
     end
 end

--- a/SpeedyWeather/test/parameterizations/ocean_sea_ice.jl
+++ b/SpeedyWeather/test/parameterizations/ocean_sea_ice.jl
@@ -23,11 +23,10 @@
             albedo = OceanLandAlbedo(ocean = OceanSeaIceAlbedo(spectral_grid), land = AlbedoClimatology(spectral_grid))
 
             model = PrimitiveDryModel(spectral_grid; ocean, sea_ice, albedo)
-            model.feedback.verbose = false
-            simulation = initialize!(model, time = DateTime(2000, 5, 1))
+            simulation = initialize!(model, time = DateTime(2000, 5, 1), feedback = Feedback(verbose = false))
             run!(simulation, period = Day(3))
 
-            @test simulation.model.feedback.nans_detected == false
+            @test simulation.feedback.nans_detected == false
             @test haskey(simulation.variables.prognostic.ocean, :sea_surface_temperature)
 
             # Some SSTs may contain NaNs
@@ -51,11 +50,10 @@
         ocean = PrescribedOcean(spectral_grid)
         sea_ice = PrescribedSeaIce(spectral_grid)
         model = PrimitiveWetModel(spectral_grid; ocean, sea_ice)
-        model.feedback.verbose = false
-        simulation = initialize!(model)
+        simulation = initialize!(model; feedback = Feedback(verbose = false))
         run!(simulation, steps = 2)
 
-        @test simulation.model.feedback.nans_detected == false
+        @test simulation.feedback.nans_detected == false
         @test haskey(simulation.variables.prognostic.ocean, :sea_surface_temperature)
         @test haskey(simulation.variables.prognostic.ocean, :sea_ice_concentration)
     end

--- a/docs/src/analysis.md
+++ b/docs/src/analysis.md
@@ -565,8 +565,8 @@ initial conditions.
 ```@example analysis
 # don't name it global_diagnostics because that's a function already!
 diagnostics_recorder = GlobalDiagnostics()
-add!(model.callbacks, :diagnostics_recorder => diagnostics_recorder)
-simulation = initialize!(model)
+callbacks = CallbackDict(:diagnostics_recorder => diagnostics_recorder)
+simulation = initialize!(model; callbacks)
 
 run!(simulation, period=Day(20))
 nothing # hide
@@ -580,8 +580,8 @@ as we do here
 using CairoMakie
 
 # unpack callback
-(; M, C, Λ, K, P, Q)  = model.callbacks[:diagnostics_recorder]
-t = model.callbacks[:diagnostics_recorder].time
+(; M, C, Λ, K, P, Q)  = simulation.callbacks[:diagnostics_recorder]
+t = simulation.callbacks[:diagnostics_recorder].time
 days = [Second(ti - t[1]).value/3600/24 for ti in t]
 
 fig = Figure();

--- a/docs/src/callbacks.md
+++ b/docs/src/callbacks.md
@@ -68,9 +68,10 @@ And we'll go through them one by one.
 ```@example callbacks
 function SpeedyWeather.initialize!(
     callback::StormChaser,
-    vars::Variables,
-    model::AbstractModel,
+    simulation::SpeedyWeather.AbstractSimulation,
 )
+    vars, model = simulation.variables, simulation.model
+
     # allocate recorder: number of time steps (incl initial conditions) in simulation
     callback.maximum_surface_wind_speed = zeros(vars.prognostic.clock.n_timesteps + 1)
 
@@ -87,10 +88,10 @@ function SpeedyWeather.initialize!(
 end
 ```
 The `initialize!` function has to be extended for the new callback `::StormChaser` as first
-argument, then followed by `vars::Variables` (all model variables) and `model`. For correct
-multiple dispatch it is important to restrict the first argument to the new `StormChaser` type
-(to not call another callback instead), but the other type declarations are for clarity only.
-`initialize!(::AbstractCallback, args...)` is called once just before the main time loop,
+argument, followed by `simulation::AbstractSimulation` from which we destructure `variables`
+and `model`. For correct multiple dispatch it is important to restrict the first argument to
+the new `StormChaser` type (to not call another callback instead).
+`initialize!(::AbstractCallback, ::AbstractSimulation)` is called once just before the main time loop,
 meaning after the initial conditions are set and after all other components are initialized.
 We replace the vector inside our storm chaser with a vector of the correct length so that
 we have a "recorder" allocated, a vector that can store the maximum surface wind speed on
@@ -117,9 +118,10 @@ Then we need to extend the `callback!` function as follows
 ```@example callbacks
 function SpeedyWeather.callback!(
     callback::StormChaser,
-    vars::Variables,
-    model::AbstractModel,
+    simulation::SpeedyWeather.AbstractSimulation,
 )
+    vars, model = simulation.variables, simulation.model
+
     # increase counter
     callback.timestep_counter += 1
     i = callback.timestep_counter
@@ -134,10 +136,11 @@ function SpeedyWeather.callback!(
 end
 ```
 The function signature for `callback!` is the same as for `initialize!`. You may
-access anything from `vars` or `model`, although for a purely diagnostic
-callback this should be read-only. While you could change other model components like the
-land sea mask in `model.land_sea_mask` or orography etc. then you interfere with the
-simulation which is more advanced and will be discussed in [Intrusive callbacks](@ref) below.
+access anything from `simulation.variables` or `simulation.model`, although for a
+purely diagnostic callback this should be read-only. While you could change other
+model components like the land-sea mask in `simulation.model.land_sea_mask` or
+orography etc. then you interfere with the simulation which is more advanced and
+will be discussed in [Intrusive callbacks](@ref) below.
 
 Lastly, we extend the `finalize!` function which is called once after the last time step.
 This could be used, for example, to save the `maximum_surface_wind_speed` vector to
@@ -158,12 +161,13 @@ SpeedyWeather.finalize!(::StormChaser, args...) = nothing
 
 ## Adding a callback
 
-Every model has a field `callbacks::Dict{Symbol, AbstractCallback}` such that the `callbacks`
-keyword can be used to create a model with a dictionary of callbacks. Callbacks are identified
-with a `Symbol` key inside such a dictionary. We have a convenient `CallbackDict` generator function
-which can be used like `Dict` but the key-value pairs have to be of type `Symbol`-`AbstractCallback`.
-Let us illustrate this with the dummy callback `NoCallback` (which is a callback that returns `nothing`
-on `initialize!`, `callback!` and `finalize!`)
+Callbacks live on the `Simulation` returned by `initialize!(model, …)`, in a
+`callbacks::Dict{Symbol, AbstractCallback}`. You can hand a dictionary of callbacks to
+`initialize!` via the `callbacks` keyword. Callbacks are identified with a `Symbol` key
+inside such a dictionary. We have a convenient `CallbackDict` generator function which can
+be used like `Dict` but the key-value pairs have to be of type `Symbol`-`AbstractCallback`.
+Let us illustrate this with the dummy callback `NoCallback` (which is a callback that returns
+`nothing` on `initialize!`, `callback!` and `finalize!`)
 
 ```@example callbacks
 callbacks = CallbackDict()                                  # empty dictionary
@@ -185,26 +189,26 @@ And you can chain them too
 add!(callbacks, NoCallback(), NoCallback())                     # random keys
 add!(callbacks, :key1 => NoCallback(), :key2 => NoCallback())   # keys provided
 ```
-Meaning that callbacks can be added before and after model construction
+Meaning that callbacks can be passed in to `initialize!`, and added before/after model construction:
 
 ```@example callbacks
 spectral_grid = SpectralGrid()
 callbacks = CallbackDict(:callback_added_before => NoCallback())
-model = PrimitiveWetModel(spectral_grid; callbacks)
-add!(model.callbacks, :callback_added_afterwards => NoCallback())
-add!(model, :callback_added_afterwards2 => NoCallback())
+model = PrimitiveWetModel(spectral_grid)
+simulation = initialize!(model; callbacks)
+add!(simulation.callbacks, :callback_added_afterwards => NoCallback())
+add!(simulation, :callback_added_afterwards2 => NoCallback())
 ```
 
-Note how the first argument can be `model.callbacks` as outlined in the sections above
-because this is the callbacks dictionary, but also simply
-`model`, which will add the callback to `model.callbacks`. It's equivalent.
+Note how the first argument can be `simulation.callbacks` (the callbacks dictionary) or just
+`simulation`, which forwards to `simulation.callbacks`. Both are equivalent.
 Let us add two more meaningful callbacks
 
 ```@example callbacks
 storm_chaser = StormChaser(spectral_grid)
 record_surface_temperature = GlobalSurfaceTemperatureCallback(spectral_grid)
-add!(model.callbacks, :storm_chaser => storm_chaser)
-add!(model.callbacks, :temperature => record_surface_temperature)
+add!(simulation.callbacks, :storm_chaser => storm_chaser)
+add!(simulation.callbacks, :temperature => record_surface_temperature)
 ```
 
 which means that now in the calls to `callback!` first the two dummy `NoCallback`s are called
@@ -215,9 +219,8 @@ only at the frequency of the model output, which for every time step would creat
 and considerably slow down the simulation. Let's run the simulation and check the callbacks
 
 ```@example callbacks
-simulation = initialize!(model)
 run!(simulation, period=Day(3))
-v = model.callbacks[:storm_chaser].maximum_surface_wind_speed
+v = simulation.callbacks[:storm_chaser].maximum_surface_wind_speed
 maximum(v)      # highest surface wind speeds in simulation [m/s]
 ```
 Cool, our `StormChaser` callback with the key `:storm_chaser` has been recording maximum
@@ -225,7 +228,7 @@ surface wind speeds in [m/s]. And the `:temperature` callback a time series of
 global mean surface temperatures in Kelvin on every time step while the model ran for 3 days.
 
 ```@example callbacks
-model.callbacks[:temperature].temperature
+simulation.callbacks[:temperature].temperature
 ```
 
 ## Intrusive callbacks
@@ -307,20 +310,19 @@ end
 
 function SpeedyWeather.initialize!(
     callback::MyScheduledCallback,
-    vars::Variables,
-    args...
+    simulation::SpeedyWeather.AbstractSimulation,
 )
     # when initializing a scheduled callback also initialize its schedule!
-    initialize!(callback.schedule, vars.prognostic.clock)
+    initialize!(callback.schedule, simulation.variables.prognostic.clock)
 
     # initialize other things in your callback here
 end
 
 function SpeedyWeather.callback!(
     callback::MyScheduledCallback,
-    vars::Variables,
-    model::AbstractModel,
+    simulation::SpeedyWeather.AbstractSimulation,
 )
+    vars = simulation.variables
     # scheduled callbacks start with this line to execute only when scheduled!
     # else escape immediately
     isscheduled(callback.schedule, vars.prognostic.clock) || return nothing
@@ -338,7 +340,7 @@ SpeedyWeather.finalize!(::MyScheduledCallback, args...) = nothing
 
 So in summary
 - add a field `schedule::Schedule` to your callback
-- add the line `initialize!(callback.schedule, vars.prognostic.clock)` when initializing your callback
+- add the line `initialize!(callback.schedule, simulation.variables.prognostic.clock)` when initializing your callback
 - start your `callback!` method with `isscheduled(callback.schedule, vars.prognostic.clock) || return nothing` to execute only when scheduled
 
 A `Schedule` is a field inside a callback as this allows you the set the callbacks
@@ -354,10 +356,10 @@ for events that are scheduled. Now let's create a primitive equation model with 
 ```@example schedule
 spectral_grid = SpectralGrid(trunc=31, nlayers=5)
 model = PrimitiveWetModel(spectral_grid)
-add!(model.callbacks, north_pole_temp_at_noon_jan9)
+callbacks = CallbackDict(:north_pole_temp_at_noon_jan9 => north_pole_temp_at_noon_jan9)
 
 # start simulation 7 days earlier
-simulation = initialize!(model, time = DateTime(2000,1,2,12))
+simulation = initialize!(model; time = DateTime(2000,1,2,12), callbacks)
 run!(simulation, period=Day(10))
 nothing # hide
 ```
@@ -369,7 +371,7 @@ we could also schedule for once a day. As illustrated in the following
 
 ```@example schedule
 north_pole_temp_daily = MyScheduledCallback(Schedule(every=Day(1)))
-add!(model.callbacks, north_pole_temp_daily)
+add!(simulation.callbacks, north_pole_temp_daily)
 
 # resume simulation, start time is now 2000-1-12 noon
 run!(simulation, period=Day(5))
@@ -419,7 +421,7 @@ will be thrown if that is the case
 
 ```@example schedule
 odd_schedule = MyScheduledCallback(Schedule(every = Minute(70)))
-add!(model.callbacks, odd_schedule)
+add!(simulation.callbacks, odd_schedule)
 
 # resume simulation for 4 hours
 run!(simulation, period=Hour(4))

--- a/docs/src/custom_netcdf_output.md
+++ b/docs/src/custom_netcdf_output.md
@@ -48,7 +48,8 @@ You can now add this variable to the `NetCDFOutput` as already described in
 
 ```@example netcdf_custom
 spectral_grid = SpectralGrid()
-output = NetCDFOutput(spectral_grid)
+model = PrimitiveDryModel(spectral_grid)
+output = NetCDFOutput(model)
 add!(output, VerticalVelocityOutput())
 ```
 
@@ -73,23 +74,20 @@ SpeedyWeather.path(::VerticalVelocityOutput, simulation) =
 
 ## Reading the new variable
 
-Now let's try this in a primitive dry model
+Now let's try this in a primitive dry model — the output writer above already
+knows about `w` because we added it before constructing the simulation.
 
 ```@example netcdf_custom
-model = PrimitiveDryModel(spectral_grid; output)
-model.output.variables[:w]
+output.variables[:w]
 ```
 
-By passing on `output` to the model constructor the output variables
-now contain `w` and we see it here as we have defined it earlier.
-
 ```@example netcdf_custom
-simulation = initialize!(model)
+simulation = initialize!(model; output)
 run!(simulation, period=Day(5), output=true)
 
 # read netcdf data
 using NCDatasets
-path = joinpath(model.output.run_path, model.output.filename)
+path = joinpath(simulation.output[1].run_path, simulation.output[1].filename)
 ds = NCDataset(path)
 ds["w"]
 ```

--- a/docs/src/examples_2D.md
+++ b/docs/src/examples_2D.md
@@ -119,7 +119,7 @@ The progress bar tells us that the simulation run got the identification "run_00
 (which just counts up, so yours might be higher), meaning that
 data is stored in the folder `run_0001`. In general we can check this also via
 ```@example galewsky_setup
-model.output.run_folder
+simulation.output[1].run_folder
 ```
 more on this in [Output path, identification and number](@ref).
 
@@ -130,8 +130,8 @@ by default this would be "run_0001/output.nc" but the run number increases when 
 before
 ```@example galewsky_setup
 using NCDatasets
-run_folder = model.output.run_folder
-filename = model.output.filename
+run_folder = simulation.output[1].run_folder
+filename = simulation.output[1].filename
 ds = NCDataset(joinpath(run_folder, filename))
 ds["vor"]
 ```
@@ -245,9 +245,9 @@ run!(simulation, period=Day(12), output=true)
 
 This time the run got a new `run_number`, which you see in the progress bar, but can again always check
 after the `run!` call (the automatic `run_number` is only determined just before the main time loop starts)
-with `model.output.run_folder`, but otherwise we do as before.
+with `simulation.output[1].run_folder`, but otherwise we do as before.
 ```@example galewsky_setup2
-run_folder = model.output.run_folder
+run_folder = simulation.output[1].run_folder
 ```
 
 ```@example galewsky_setup2

--- a/docs/src/how_to_run_speedy.md
+++ b/docs/src/how_to_run_speedy.md
@@ -194,15 +194,21 @@ zenith angle calculation.
 
 After this step you can continue to tweak your model setup but note that
 some model components are immutable, or that your changes may not be
-propagated to other model components that rely on it. But you can, for
-example, change the output interval like so
+propagated to other model components that rely on it. Output writers are
+attached to the `Simulation` itself, not the model. To get NetCDF output
+every hour, build the writer and pass it to `initialize!(model)`:
 ```@example howto
-set!(model.output, model, interval=Hour(1))
+output = NetCDFOutput(model, interval=Hour(1))
+simulation = initialize!(model; output)
 ```
-Now, if there's output, it will be every hour. Furthermore the initial
-conditions can be set with the `initial_conditions` model component
-which are then set during `initialize!(::AbstractModel)`, but you can also
-change them now, before the model runs 
+If an output writer already exists, you can also retune its `interval`
+on the fly:
+```@example howto
+set!(output, model, simulation.callbacks; interval=Hour(1))
+```
+Furthermore the initial conditions can be set with the `initial_conditions`
+model component which are then set during `initialize!(::AbstractModel)`, but
+you can also change them now, before the model runs
 ```@example howto
 # harmonic x layer x leapfrog steps
 simulation.variables.prognostic.vorticity[1, 1, 1] = 0
@@ -223,7 +229,7 @@ run!(simulation)
 By default this runs for 10 days without output and returns the updated `simulation`.
 Now `period` and `output` are the only options to change, so with
 ```@example howto
-model.output.id = "test" # hide
+output.id = "test" # hide
 run!(simulation, period=Day(5), output=true)
 ```
 You would continue this simulation (the previous `run!` call already integrated

--- a/docs/src/land.md
+++ b/docs/src/land.md
@@ -398,8 +398,9 @@ The albedo in the `model` is now the one defined just in the lines above,
 using a globally constant albedo of 0.1 for the ocean but a higher albedo
 over land which also increases to 0.5 towards the poles.
 
-You can always output the land-sea mask weighted albedo with
-`add!(model, SpeedyWeather.AlbedoOutput())` or inspect it as follows
+You can always output the land-sea mask weighted albedo by building a
+`NetCDFOutput` and `add!(output, SpeedyWeather.AlbedoOutput())`, or inspect
+it as follows
 
 ```@example land
 simulation = initialize!(model)

--- a/docs/src/land_sea_mask.md
+++ b/docs/src/land_sea_mask.md
@@ -166,9 +166,9 @@ would then have this `MilleniumFlood` take place
 ```@example landseamask
 land_sea_mask = LandSeaMask(spectral_grid)      # start with Earth's land-sea mask
 model = PrimitiveWetModel(spectral_grid; land_sea_mask)
-add!(model, MilleniumFlood())   # or MilleniumFlood(::DateTime) for any non-default date
+callbacks = CallbackDict(:millenium_flood => MilleniumFlood())   # or MilleniumFlood(::DateTime) for any non-default date
 
-simulation = initialize!(model, time=DateTime(1999,12,29))
+simulation = initialize!(model; time=DateTime(1999,12,29), callbacks)
 run!(simulation, period=Day(5))
 heatmap(model.land_sea_mask.mask, title="Land-sea mask after MilleniumFlood callback")
 save("land-sea_mask2.png", ans) # hide

--- a/docs/src/ocean.md
+++ b/docs/src/ocean.md
@@ -130,16 +130,17 @@ nothing # hide
 
 ## Output
 
-Sea surface temperature output is added like
+Sea surface temperature output is added to the `NetCDFOutput` writer like
 
 ```@example ocean
-add!(model, SpeedyWeather.SeaSurfaceTemperatureOutput())
+output = NetCDFOutput(model)
+add!(output, SpeedyWeather.SeaSurfaceTemperatureOutput())
 ```
 
 or collectively with sea ice concentration
 
 ```@example ocean
-add!(model, SpeedyWeather.OceanOutput())
+add!(output, SpeedyWeather.OceanOutput())
 ```
 
 All output variable groups are defined as tuples which are implicitly splatted (`...`).

--- a/docs/src/other_output.md
+++ b/docs/src/other_output.md
@@ -3,7 +3,7 @@
 Next to the [NetCDF output](@ref) there's other ways to output data from
 the model, these are described below.
 
-## JLD2 Output 
+## JLD2 Output
 
 As an alternative to the [NetCDF output](@ref), it is also possible to directly
 output the `Variables` (or one subgroup of it) to a JLD2 file.
@@ -18,12 +18,13 @@ Its usage is similar to the NetCDF output above:
 ```@example output2
 using SpeedyWeather
 spectral_grid = SpectralGrid(trunc=31, nlayers=1)
+model = ShallowWaterModel(spectral_grid)
 output = JLD2Output(interval=Hour(1))
-model = ShallowWaterModel(spectral_grid, output=output)
-model.output
+simulation = initialize!(model; output)
+output
 ```
 
-With all options shown below 
+With all options shown below
 
 ````@docs; canonical=false
 JLD2Output
@@ -31,21 +32,22 @@ JLD2Output
 
 ## Array Output (to RAM)
 
-It's also possible to output the `Variables` (or a subgroup of it) directly into an array that is kept in the memory. This might be useful e.g. for low-resolution simulations you want to work with and visualize quickly, or also for simulations within ML training loops. `ArrayOutput` follows the exact same logic as `JLD2Output` except that the actual output is kept in an array `output`. So, save e.g. all prognostic variables to memory, you can run: 
+It's also possible to output the `Variables` (or a subgroup of it) directly into an array that is kept in the memory. This might be useful e.g. for low-resolution simulations you want to work with and visualize quickly, or also for simulations within ML training loops. `ArrayOutput` follows the exact same logic as `JLD2Output` except that the actual output is kept in an array `output`. So, save e.g. all prognostic variables to memory, you can run:
 
 ```@example output3
 using SpeedyWeather
 spectral_grid = SpectralGrid(trunc=31, nlayers=1)
+model = ShallowWaterModel(spectral_grid)
 output = ArrayOutput(interval=Hour(1), groups=(:prognostic,))
-model = ShallowWaterModel(spectral_grid, output=output)
-model.output
+simulation = initialize!(model; output)
+output
 ```
 
-After a succesfull `run!` the result is stored in `output.output`. 
+After a succesfull `run!` the result is stored in `output.output`.
 
 ## Zarr Output
 
-[Zarr](https://zarr.dev) is a chunked, compressed, cloud-friendly format for N-dimensional arrays. 
+[Zarr](https://zarr.dev) is a chunked, compressed, cloud-friendly format for N-dimensional arrays.
 
 `ZarrOutput` is implemented as an **extension** that is only loaded once
 [Zarr.jl](https://github.com/JuliaIO/Zarr.jl) is imported:
@@ -55,15 +57,15 @@ using SpeedyWeather
 using Zarr     # this loads SpeedyWeatherZarrExt and enables ZarrOutput
 
 spectral_grid = SpectralGrid(trunc=31, nlayers=8)
-output = ZarrOutput(spectral_grid, PrimitiveWet, interval=Hour(6))
-model = PrimitiveWetModel(spectral_grid; output)
-simulation = initialize!(model)
+model = PrimitiveWetModel(spectral_grid)
+output = ZarrOutput(model, interval=Hour(6))
+simulation = initialize!(model; output)
 run!(simulation, period=Day(10), output=true)
 nothing #hide
 ```
 
 The constructor and option fields mirror [`NetCDFOutput`](@ref): `path`, `id`, `overwrite`,
-`output_dt`, `variables`, `write_restart`, `write_parameters_txt`, `write_progress_txt` all
+`interval`, `variables`, `write_restart`, `write_parameters_txt`, `write_progress_txt` all
 behave the same way, the run folder layout (`run_<id>_NNNN/`) is identical, and the same
 `AbstractOutputVariable` types are used to declare which variables are written.
 The on-disk layout differs:
@@ -84,8 +86,9 @@ Two extra options are specific to `ZarrOutput`:
 using SpeedyWeather, Zarr
 
 spectral_grid = SpectralGrid(trunc=31, nlayers=8)
-output = ZarrOutput(spectral_grid, PrimitiveWet;
-    output_dt = Hour(1),
+model = PrimitiveWetModel(spectral_grid)
+output = ZarrOutput(model;
+    interval = Hour(1),
     time_chunk = 24,                        # bundle one day per chunk on the time axis
     compressor = Zarr.BloscCompressor(clevel=5),
 )
@@ -104,11 +107,11 @@ nothing #hide
 Custom output variables work exactly as with `NetCDFOutput`: subtype
 `AbstractOutputVariable`, implement `path(::MyOutputVariable, simulation)` to
 return the `AbstractField` to write, and `add!(output, MyOutputVariable())` it to the
-`ZarrOutput`. 
+`ZarrOutput`.
 
 ### Reading the store from Python with xarray
 
-`ZarrOutput` writes the stores according to the conventions of `xarray` to ensure compability with it. Simulations can be easily opened in Python as in the following: 
+`ZarrOutput` writes the stores according to the conventions of `xarray` to ensure compability with it. Simulations can be easily opened in Python as in the following:
 
 ```python
 import xarray as xr
@@ -150,26 +153,21 @@ a [Callbacks](@ref) (`<: SpeedyWeather.AbstractCallback`) and can be added indep
 
 ```@example output2
 # run an example simulation with output
-simulation = initialize!(model)
+simulation = initialize!(model; output)
 run!(simulation, period=Hour(4), output=true)
 
-# now model.output will have added additional "output" writers
-simulation.model.callbacks
+# the simulation now has the callbacks attached
+simulation.callbacks
 ```
 
-but it's activity is by default tied to activity of the `NetCDFOutput` with
-you can control with `write_only_with_output`.
-Creating such a callback independently
+`ParametersTxt` is added automatically by `NetCDFOutput.write_parameters_txt = true` (the
+default) and gets the writer's `run_path` filled in. You can also create one independently
+and attach it to a simulation with `add!`:
 
 ```@example output2
-parameters_txt = ParametersTxt(write_only_with_output=false)
-```
-
-we can add it with a random or manual key as
-
-```@example output2
-add!(model, parameters_txt)             # random key
-add!(model, :my_key => parameters_txt)  # manual key
+parameters_txt = ParametersTxt(path = "myfolder")
+add!(simulation, parameters_txt)            # random key
+add!(simulation, :my_key => parameters_txt) # manual key
 ```
 
 But note that callbacks are overwritten with identical keys, otherwise treated independently.
@@ -182,13 +180,13 @@ Similarly to `ParametersTxt`, a callback `ProgressTxt` is by default added with 
 They can be created independently too
 
 ```@example output2
-progress_txt = ProgressTxt(write_only_with_output=false, path="myfolder", filename="letsgo.txt")
+progress_txt = ProgressTxt(path="myfolder", filename="letsgo.txt")
 ```
 
 and added like
 
 ```@example output2
-add!(model, :progress_txt => progress_txt)
+add!(simulation, :progress_txt => progress_txt)
 ```
 
 ## Restart files for variables
@@ -198,13 +196,13 @@ that can be read back in with the `StartFromFile` initial conditions. Implemente
 `WriteVariablesRestartFile` can also be created independently of `NetCDFOutput`, e.g.
 
 ```@example output2
-restart_file = WriteVariablesRestartFile(write_only_with_output=false, path="folder1", filename="restart.jld2")
+restart_file = WriteVariablesRestartFile(path="folder1", filename="restart.jld2")
 ```
 
 and added like
 
 ```@example output2
-add!(model, :restart_file => restart_file)
+add!(simulation, :restart_file => restart_file)
 ```
 
 By default `path=""` will use the folder determined by `NetCDFOutput` but otherwise you can
@@ -222,7 +220,8 @@ orography = ManualOrography(spectral_grid)  # an orography that is untouched at 
 model = ShallowWaterModel(spectral_grid; orography)
 set!(model, orography=123)                  # set as you like
 orography_for_restart = WriteModelComponentFile(component=model.orography, filename="my_orography.jld2")
-add!(model, :my_orography => orography_for_restart)
+simulation = initialize!(model)
+add!(simulation, :my_orography => orography_for_restart)
 ```
 
 Once the simulation ran you can then load this model component from file and use it to construct
@@ -230,7 +229,6 @@ a new model with it, or use its information in some other form, e.g. by writing 
 other arrays:
 
 ```@example output2
-simulation = initialize!(model)
 run!(simulation, steps=0, output=true)
 
 # either pass on that same callback (which will read out the path) or provide path directly
@@ -244,11 +242,11 @@ all(new_model.orography.orography .== 123)  # check that the new orography is in
 We do not really want to encourage it, but `WriteModelComponentFile` can be hijacked to write out the entire `model`.
 While this easily saves everything of `model` into one file, it always writes many large precomputed arrays to file
 whereas they could just be recomputed when constructing a new model. For example, the Legendre polynomials in
-`model.spectral_transform` can easily be GBs at higher resolution, see also 
+`model.spectral_transform` can easily be GBs at higher resolution, see also
 [Precomputed polynomials and allocated memory](@ref). Nevertheless, you can write out the entire model with
 
 ```@example output2
-add!(model, :model_writer => WriteModelComponentFile(component=model, filename="model.jld2"))
+add!(simulation, :model_writer => WriteModelComponentFile(component=model, filename="model.jld2"))
 ```
 
 Note that this callback contains a `model` that also contains this callback.

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -6,50 +6,48 @@ There are many options to this available.
 
 ## Creating `NetCDFOutput`
 
+The `NetCDFOutput` writer is constructed from a fully-built model — it inspects the model
+to set up the interpolator, scratch fields and the default output variables for the model
+class (e.g. `BarotropicModel` outputs vorticity and the velocity components; primitive models
+also include temperature and humidity).
+
 ```@example netcdf
 using SpeedyWeather
 spectral_grid = SpectralGrid()
-output = NetCDFOutput(spectral_grid)
-```
-
-With `NetCDFOutput(::SpectralGrid, ...)` one creates a `NetCDFOutput` writer with several options,
-which are explained in the following. By default, the `NetCDFOutput` is created when constructing
-the model, i.e.
-
-```@example netcdf
 model = ShallowWaterModel(spectral_grid)
-model.output
+output = NetCDFOutput(model)
 ```
 
-The output writer is a component of every Model, i.e. `BarotropicModel`, `ShallowWaterModel`, `PrimitiveDryModel`
-and `PrimitiveWetModel`, and they only differ in their default `output.variables` (e.g. the primitive
-models would by default output temperature which does not exist in the 2D models `BarotropicModel` or `ShallowWaterModel`).
-But any `NetCDFOutput` can be passed onto the model constructor with the `output` keyword argument.
+The output writer is then attached to the simulation by passing it as the `output` keyword
+argument to `initialize!(model)`:
 
 ```@example netcdf
-output = NetCDFOutput(spectral_grid, Barotropic)
-model = ShallowWaterModel(spectral_grid, output=output)
-nothing # hide
+simulation = initialize!(model; output)
+simulation
 ```
 
-Here, we created `NetCDFOutput` for the model class `Barotropic` (2nd positional argument, outputting only vorticity and velocity)
-but use it in the `ShallowWaterModel`. By default the `NetCDFOutput` is set to inactive, i.e.
-`output.active` is `false`. It is only turned on (and initialized) with `run!(simulation, output=true)`.
-So you may change the `NetCDFOutput` as you like but only calling `run!(simulation)` will not
-trigger it as `output=false` is the default here.
+A `Simulation` carries its output writers, callbacks and runtime feedback (they no longer
+live on the model itself). The writer is inactive at construction; it is only turned on
+(and the run folder created) when you call `run!(simulation, output=true)`.
+
+You can attach multiple writers at the same time — pass a tuple of writers to `initialize!`:
+
+```julia
+simulation = initialize!(model; output = (NetCDFOutput(model), ZarrOutput(model)))
+```
+
+Both writers will share the simulation's clock and write into their own run folders.
 
 ## Output frequency
 
 If we want to increase the frequency of the output we can choose `interval` (default `=Hour(6)`) like so
 ```@example netcdf
-output = NetCDFOutput(spectral_grid, ShallowWater, interval=Hour(1))
-model = ShallowWaterModel(spectral_grid, output=output)
-model.output
+output = NetCDFOutput(model, interval=Hour(1))
+simulation = initialize!(model; output)
+simulation
 ```
-which will now output every hour. It is important to pass on the new output writer `output` to the
-model constructor, otherwise it will not be part of your model and the default is used instead.
-Note that the choice of `interval` can affect the actual time step that is used for the model
-integration, which is explained in the following.
+which will now output every hour. Note that the choice of `interval` can affect the actual
+time step that is used for the model integration, which is explained in the following.
 Example, we run the model at a resolution of T42 and the time step is going to be
 ```@example netcdf
 spectral_grid = SpectralGrid(trunc=42, nlayers=1)
@@ -59,9 +57,9 @@ time_stepping.Δt_sec
 seconds. Depending on the output frequency (we chose `interval = Hour(1)` above)
 this will be slightly adjusted during model initialization:
 ```@example netcdf
-output = NetCDFOutput(spectral_grid, ShallowWater, interval=Hour(1))
-model = ShallowWaterModel(spectral_grid; time_stepping, output)
-simulation = initialize!(model)
+model = ShallowWaterModel(spectral_grid; time_stepping)
+output = NetCDFOutput(model, interval=Hour(1))
+simulation = initialize!(model; output)
 model.time_stepping.Δt_sec
 ```
 The shorter the output interval the more the model time step needs to be adjusted
@@ -75,27 +73,26 @@ time_stepping.Δt_sec
 and a little info will be printed to explain that even though you wanted
 `interval = Hour(1)` you will not actually get this upon initialization:
 ```@example netcdf
-model = ShallowWaterModel(spectral_grid; time_stepping, output)
-simulation = initialize!(model)
+model = ShallowWaterModel(spectral_grid; time_stepping)
+output = NetCDFOutput(model, interval=Hour(1))
+simulation = initialize!(model; output)
 ```
 
 The time axis of the NetCDF output will now look like
 ```@example netcdf
 using NCDatasets
 run!(simulation, period=Day(1), output=true)
-run_folder = model.output.run_folder
-ds = NCDataset("$run_folder/output.nc")
+ds = NCDataset(joinpath(output.run_path, output.filename))
 ds["time"][:]
 ```
 which is a bit ugly, that's why `adjust_with_output=true` is the default. In that case we would have
 ```@example netcdf
 time_stepping = Leapfrog(spectral_grid, adjust_with_output=true)
-output = NetCDFOutput(spectral_grid, ShallowWater, interval=Hour(1))
-model = ShallowWaterModel(spectral_grid; time_stepping, output)
-simulation = initialize!(model)
+model = ShallowWaterModel(spectral_grid; time_stepping)
+output = NetCDFOutput(model, interval=Hour(1))
+simulation = initialize!(model; output)
 run!(simulation, period=Day(1), output=true)
-run_folder = model.output.run_folder
-ds = NCDataset("$run_folder/output.nc")
+ds = NCDataset(joinpath(output.run_path, output.filename))
 ds["time"][:]
 ```
 very neatly hourly output in the NetCDF file!
@@ -109,7 +106,7 @@ So for example `output_grid=FullClenshawGrid(48)` would interpolate onto a
 regular 192x95 longitude-latitude grid of 1.875˚ resolution, regardless the grid and resolution used
 for the model integration.
 ```@example netcdf
-my_output_writer = NetCDFOutput(spectral_grid, output_grid=FullClenshawGrid(48))
+my_output_writer = NetCDFOutput(model, output_grid=FullClenshawGrid(48))
 ```
 Note that by default the output is on the corresponding full type of the grid type used in the dynamical core
 so that interpolation only happens at most in the zonal direction as they share the location of the
@@ -160,15 +157,12 @@ is discussed in [Customizing netCDF output](@ref).
 We can add new output variables with `add!`
 
 ```@example netcdf
-output = NetCDFOutput(spectral_grid)            # default variables
+output = NetCDFOutput(model)                    # default variables
 add!(output, SpeedyWeather.DivergenceOutput())  # output also divergence
 output
 ```
 
-If you didn't create a `NetCDFOutput` separately, you can also apply this directly to `model`,
-either `add!(model, SpeedyWeather.DivergenceOutput())` or `add!(model.output, args...)`,
-which technically also just forwards to `add!(model.output.variables, args...)`.
-`output.variables` is a dictionary were the variable names (as `Symbol`s) are used as keys,
+`output.variables` is a dictionary where the variable names (as `Symbol`s) are used as keys,
 so `output.variables[:div]` just returns the `SpeedyWeather.DivergenceOutput()` we have
 just created using `:div` as key. With those keys one can also `delete!` a variable
 from netCDF output
@@ -233,7 +227,9 @@ SpeedyWeather.AllOutputVariabesl()
 each of can but doesn't have to be splatted e.g.
 
 ```@example netcdf
-add!(model, SpeedyWeather.SurfaceFluxesOutput())
+model = PrimitiveWetModel(spectral_grid)
+output = NetCDFOutput(model)
+add!(output, SpeedyWeather.SurfaceFluxesOutput())
 ```
 
 or `SpeedyWeather.SurfaceFluxesOutput()...` are equivalent.
@@ -255,18 +251,19 @@ Otherwise (`overwrite=false`) we (re)set the run number to 1, check whether the 
 already exists and count the run number up until no folder of that same name already exists.
 
 ```@example netcdf
+model = BarotropicModel(spectral_grid)
+
 # default naming run_0001, run_0002, ...
-output = NetCDFOutput(spectral_grid)
+output = NetCDFOutput(model)
 
 # provide an id, would yield run_test_0001, run_test_0002, ...
-output = NetCDFOutput(spectral_grid, id="test")
+output = NetCDFOutput(model, id="test")
 
 # write into run_forrest_run_01234 potentially ovewriting it
-output = NetCDFOutput(spectral_grid, id="forrest_run", run_number=1234, run_digits=5, overwrite=true)
+output = NetCDFOutput(model, id="forrest_run", run_number=1234, run_digits=5, overwrite=true)
 
 # let us test the last one
-model = BarotropicModel(spectral_grid; output)
-simulation = initialize!(model)
+simulation = initialize!(model; output)
 run!(simulation, steps=1, output=true)
 
 # what is the run folder?
@@ -296,11 +293,12 @@ The saved NetCDF files can be visualized with a wide range of tools, both in Jul
 using SpeedyWeather, GeoMakie, CairoMakie
 spectral_grid = SpectralGrid()
 model = PrimitiveWetModel(spectral_grid)
-simulation = initialize!(model)
+output = NetCDFOutput(model)
 
 # Add mean sea-level pressure for visualisation
-add!(model, SpeedyWeather.MeanSeaLevelPressureOutput())
+add!(output, SpeedyWeather.MeanSeaLevelPressureOutput())
 
+simulation = initialize!(model; output)
 run!(simulation, period=Day(3), output=false) # some spin-up
 run!(simulation, period=Day(5), output=true)
 

--- a/docs/src/particles.md
+++ b/docs/src/particles.md
@@ -235,28 +235,27 @@ The callback is then added after the model is created
 ```@example particle_tracker
 particle_advection = ParticleAdvection2D(spectral_grid, nparticles = 100)
 model = ShallowWaterModel(spectral_grid; particle_advection)
-add!(model.callbacks, particle_tracker)
+callbacks = CallbackDict(:particle_tracker => particle_tracker)
+simulation = initialize!(model; callbacks)
 ```
 
-which will give it a random key too in case you need to remove it again (more on this in
-[Callbacks](@ref)). If you now run the simulation the particle tracker is called on
-`particle_tracker.every_n_timesteps` and it continuously writes into `particle_tracker.netcdf_file`
-which is placed in the run folder similar to other [NetCDF output](@ref). For example,
-the run folder can be obtained after the simulation by `model.output.run_folder`.
+If you now run the simulation the particle tracker is called on
+`particle_tracker.every_n_timesteps` and it continuously writes into `particle_tracker.netcdf_file`.
+If a `NetCDFOutput` is attached to the simulation, the tracker shares its run folder; otherwise
+it writes into the current working directory (or whatever `path` you set when constructing
+the `ParticleTracker`). After the simulation, `particle_tracker.path` tells you where
+the file ended up.
 
 ```@example particle_tracker
-simulation = initialize!(model)
 run!(simulation, period = Day(10))
-model.output.run_folder
+particle_tracker.path
 ```
 
-As we don't have `output = true`, by default, the `particles.nc` file will be written
-the to current working directory. You can read the netCDF file with
+You can read the netCDF file with
 
 ```@example particle_tracker
 using NCDatasets
-run_folder = model.output.run_folder                    # if output = true the run_???? string with run number
-path = joinpath(run_folder, particle_tracker.filename)  # "particles.nc" by default if output = false
+path = joinpath(particle_tracker.path, particle_tracker.filename)
 ds = NCDataset(path)
 ds["lon"]
 ds["lat"]

--- a/docs/src/sea_ice.md
+++ b/docs/src/sea_ice.md
@@ -109,16 +109,17 @@ no insulation (i.e. no impact) in the case of no ice.
 
 ## Output
 
-And output is added like
+And output is added to the `NetCDFOutput` writer like
 
 ```@example sea_ice
-add!(model, SpeedyWeather.SeaIceConcentrationOutput())
+output = NetCDFOutput(model)
+add!(output, SpeedyWeather.SeaIceConcentrationOutput())
 ```
 
 or as part of `SpeedyWeather.OceanOutput()`
 
 ```@example sea_ice
-add!(model, SpeedyWeather.OceanOutput())
+add!(output, SpeedyWeather.OceanOutput())
 ```
 
 For more information see [Output variables](@ref).

--- a/docs/src/tracers.md
+++ b/docs/src/tracers.md
@@ -193,11 +193,13 @@ nothing # hide
 ## Output tracers
 
 This follows equivalent to other [Output variables](@ref) but the
-tracer name as `Symbol` has to be provided
+tracer name as `Symbol` has to be provided. Add it to a `NetCDFOutput`
+writer:
 
 ```@example tracers
-add!(model, SpeedyWeather.TracerOutput(:abc))
+output = NetCDFOutput(model)
+add!(output, SpeedyWeather.TracerOutput(:abc))
 ```
 
 and other keyword arguments like `long_name::String` and `units::String`
-can be passed on too. 
+can be passed on too.


### PR DESCRIPTION
Draft made with Claude. 

I am not super convinced as this is really a massive breaking change. Let's discuss it, but I think other things have priority. The time stepping would need a few further changes to clean this up. 

In principle though I do think that the model types should hold the physical model specifications only and output related functions should rather fit in the simulation. But this isn't something very urgent. 

Unit tests all pass locally. 