### PR TITLE
Fix wrong dynamics setting in ic-example

### DIFF
--- a/docs/src/initial_conditions.md
+++ b/docs/src/initial_conditions.md
@@ -196,7 +196,7 @@ The following shows how you can use `RossbyHaurwitzWave`
 in a `PrimitiveDryModel` (or `Wet`) but you probably
 also want to set initial conditions for temperature and pressure
 to not start at zero Kelvin and zero pressure. Also no orography,
-and let's switch off all physics parameterizations with `physics=false`.
+and let's switch off all physics parameterizations with `dynamics_only=true`.
 
 ```@example haurwitz
 spectral_grid = SpectralGrid(trunc=42, nlayers=8)
@@ -211,7 +211,7 @@ time_stepping = Leapfrog(spectral_grid, Δt_at_T31=Minute(30))   # 30min timeste
 forcing = nothing
 drag = nothing
 
-model = PrimitiveDryModel(spectral_grid; time_stepping, initial_conditions, orography, forcing, drag, dynamics_only=false)
+model = PrimitiveDryModel(spectral_grid; time_stepping, initial_conditions, orography, forcing, drag, dynamics_only=true)
 simulation = initialize!(model)
 run!(simulation, period=Day(5))
 nothing # hide


### PR DESCRIPTION
Hi,

there was a  relict in the Rossby-Haurwitz wave example in the [initial condition](https://speedyweather.github.io/SpeedyWeatherDocumentation/dev/initial_conditions#Rossby-Haurwitz-wave-in-primitive-equations) section leading to a wrong plot.

The text mentioned (the old) setting `physics=false` but then set `dynamics_only=false` as the model argument.