### PR TITLE
Scale time step on the fly and forcing/drag/parameterizations inside dycore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Scale time step on the fly [#1139](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1139)
 - ArrayWorkOrder instead of Array3DWorkOrder as both preserve dimensions [#1127](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1127)
 - Allocation-free masked copy between RingGrids Field and subset array via mask [#1127](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1127)
 - Rename land-sea mask array land_fraction [#1219](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1134)

--- a/SpeedyWeather/benchmark/benchmark_suite.jl
+++ b/SpeedyWeather/benchmark/benchmark_suite.jl
@@ -101,7 +101,7 @@ function run_benchmark_suite!(suite::BenchmarkSuite)
         suite.memory[i] = Base.summarysize(simulation)
 
         nsteps = n_timesteps(trunc, nlayers)
-        period = Second(round(Int, model.time_stepping.Δt_sec * (nsteps + 1)))
+        period = Second(round(Int, model.time_stepping.Δt * (nsteps + 1)))
 
         # Warm up before timing: run a few steps so JIT compilation of the time
         # loop happens here rather than inside the timed run below. The timed run
@@ -112,7 +112,7 @@ function run_benchmark_suite!(suite::BenchmarkSuite)
         # reuses the compiled code). A handful of steps covers the Euler spin-up
         # plus regular steps. We then re-initialize so the timed run starts from
         # the same initial state as before.
-        warmup_period = Second(round(Int, model.time_stepping.Δt_sec * 3))
+        warmup_period = Second(round(Int, model.time_stepping.Δt * 3))
         run!(simulation; period = warmup_period)
         synchronize(architecture)
 
@@ -121,9 +121,9 @@ function run_benchmark_suite!(suite::BenchmarkSuite)
         synchronize(architecture)
 
         time_elapsed = model.feedback.progress_meter.tlast - model.feedback.progress_meter.tinit
-        sypd = model.time_stepping.Δt_sec * nsteps / (time_elapsed * 365.25)
+        sypd = model.time_stepping.Δt * nsteps / (time_elapsed * 365.25)
 
-        suite.Δt[i] = model.time_stepping.Δt_sec
+        suite.Δt[i] = model.time_stepping.Δt
         suite.SYPD[i] = sypd
     end
     return

--- a/SpeedyWeather/src/dynamics/coriolis.jl
+++ b/SpeedyWeather/src/dynamics/coriolis.jl
@@ -5,7 +5,7 @@ export Coriolis
 """Model component holding the Coriolis parameter `f` on the model grid,
 a vector over the latitude rings. $(TYPEDFIELDS)"""
 @kwdef struct Coriolis{VectorType} <: AbstractCoriolis
-    "[DERIVED] Coriolis frequency [s^-1], scaled by radius as is vorticity = 2Ω*sin(lat)*radius"
+    "[DERIVED] Coriolis frequency [s^-1], = 2Ω*sin(lat)"
     f::VectorType
 end
 
@@ -15,11 +15,9 @@ Adapt.@adapt_structure Coriolis
 Coriolis(SG::SpectralGrid) = Coriolis(on_architecture(SG.architecture, zeros(SG.NF, SG.nlat)))
 
 function initialize!(coriolis::Coriolis, model::AbstractModel)
-    (; radius, rotation) = model.planet
+    (; rotation) = model.planet
     (; sinlat) = model.geometry
-
-    # =2Ωsin(lat) but scaled with radius as are the equations
-    coriolis.f .= 2rotation * sinlat * radius
+    coriolis.f .= 2rotation * sinlat
     return nothing
 end
 

--- a/SpeedyWeather/src/dynamics/drag.jl
+++ b/SpeedyWeather/src/dynamics/drag.jl
@@ -59,10 +59,8 @@ function drag!(
     Fu = get_tendency_step(vars.tendencies.grid.u, model.time_stepping, drag)
     Fv = get_tendency_step(vars.tendencies.grid.v, model.time_stepping, drag)
 
-    # include radius scaling
-    c = vars.prognostic.scale[]
-    @. Fu -= c * drag.drag_coefs' .* u
-    @. Fv -= c * drag.drag_coefs' .* v
+    @. Fu -= drag.drag_coefs' .* u
+    @. Fv -= drag.drag_coefs' .* v
 
     return nothing
 end
@@ -98,11 +96,8 @@ function drag!(
     Fu = get_tendency_step(vars.tendencies.grid.u, model.time_stepping, scheme)
     Fv = get_tendency_step(vars.tendencies.grid.v, model.time_stepping, scheme)
 
-    # total drag coefficient with radius scaling
-    # note that while the equations (with prognostic variable vorticity) are scaled
-    # with radius R squared, one R will go into the curl operator applied to forcing of u, v
-    # to yield a tendency for vorticity, so only one R is needed here in the drag coefficient scaling
-    c = scheme.drag / model.atmosphere.layer_thickness * vars.prognostic.scale[]
+    # total drag coefficient
+    c = scheme.drag / model.atmosphere.layer_thickness
 
     launch!(
         architecture(Fu), LinearWorkOrder, (size(Fu, 1),), quadratic_drag_kernel!,
@@ -156,8 +151,8 @@ function drag!(
     Fu = get_tendency_step(vars.tendencies.grid.u, model.time_stepping, scheme)
     Fv = get_tendency_step(vars.tendencies.grid.v, model.time_stepping, scheme)
 
-    # total drag coefficient with radius scaling
-    c = scheme.drag * vars.prognostic.scale[]
+    # total drag coefficient
+    c = scheme.drag
     (; speed_limit) = scheme
 
     launch!(
@@ -200,11 +195,7 @@ function drag!(
     )
     vor_tend = get_tendency_step(vars.tendencies.vorticity, model.time_stepping, drag)
     vor = get_prognostic_step(vars.prognostic.vorticity, model.time_stepping, drag)
-
-    # scale by radius (but only once, the second radius is in vor)
-    c = drag.c * vars.prognostic.scale[]
-    vor_tend .-= c * vor
-
+    vor_tend .-= drag.c * vor
     return nothing
 end
 
@@ -258,10 +249,8 @@ function drag!(
     vor_tend = get_tendency_step(vars.tendencies.vorticity, model.time_stepping, drag)
     (; ζ₀) = drag
 
-    # scale by radius as is vorticity
-    s = vars.prognostic.scale[]
-    r = s / drag.time_scale.value
-
+    # drag coefficient r as inverse time scale [1/s]
+    r = inv(drag.time_scale.value)
     k = size(vor, 2)   # drag only on surface layer
 
     # GPU kernel launch

--- a/SpeedyWeather/src/dynamics/forcing.jl
+++ b/SpeedyWeather/src/dynamics/forcing.jl
@@ -53,14 +53,12 @@ function initialize!(
     )
 
     (; latitude, width, speed, time_scale, amplitude) = forcing
-    (; radius) = model.planet
 
     # Some constants similar to Galewsky 2004
     θ₀ = (latitude - width) / 360 * 2π          # southern boundary of jet [radians]
     θ₁ = (latitude + width) / 360 * 2π          # northern boundary of jet
     eₙ = exp(-4 / (θ₁ - θ₀)^2)                  # normalisation, so that speed is at max
     A₀ = speed / eₙ / time_scale.value          # amplitude [m/s²] without lat dependency
-    A₀ *= radius                                # scale by radius as are the momentum equations
 
     (; colat) = model.geometry
     # latitude in radians, abs for north/south symmetry
@@ -182,8 +180,8 @@ function forcing!(
     S_masked = vars.scratch.a_2D
     transform!(S_masked, S_grid, vars.scratch.transform_memory, spectral_transform)
 
-    # scale by radius^2 as is the vorticity equation, and scale to forcing strength
-    S_masked .*= (vars.prognostic.scale[]^2 * forcing.strength)
+    # scale by radius as is vorticity, and scale to forcing strength
+    S_masked .*= (vars.prognostic.scale[] * forcing.strength)
 
     # force every layer
     vor_tend = get_tendency_step(vars.tendencies.vorticity, time_stepping, forcing)
@@ -231,8 +229,7 @@ function forcing!(
         model::AbstractModel,
     )
     (; latds) = model.geometry
-    # scale by radius as is the vorticity equation
-    s = forcing.strength * vars.prognostic.scale[]
+    s = forcing.strength
     k = forcing.wavenumber
 
     Fu = get_tendency_step(vars.tendencies.grid.u, model.time_stepping, forcing)
@@ -318,7 +315,6 @@ function initialize!(
     (; σb, ΔTy, Δθz, relax_time_slow, relax_time_fast, Tmax) = forcing
     (; log_σ, temp_relax_freq, temp_equil_a, temp_equil_b) = forcing
     p₀ = model.atmosphere.reference_pressure
-    (; radius) = model.planet
 
     # slow relaxation everywhere, fast in the tropics
     kₐ = 1 / Second(relax_time_slow).value
@@ -329,7 +325,6 @@ function initialize!(
 
     # Held and Suarez equation 4
     temp_relax_freq .= kₐ .+ (kₛ - kₐ) * max.(0, (σ .- σb) ./ (1 - σb)) .* (coslat') .^ 4
-    temp_relax_freq .*= radius  # scale by radius as is the temperature equation
 
     # Held and Suarez equation 3, split into max(Tmin, (a + b*ln(p))*(p/p₀)^κ)
     # precompute a, b to simplify online calculation

--- a/SpeedyWeather/src/dynamics/geopotential.jl
+++ b/SpeedyWeather/src/dynamics/geopotential.jl
@@ -211,9 +211,9 @@ end
 $(TYPEDSIGNATURES)
 calculates the geopotential in the ShallowWaterModel as g*η,
 i.e. gravity times the interface displacement (field `pres`)"""
-function geopotential!(vars::Variables, planet::AbstractPlanet)
+function geopotential!(vars::Variables, model::ShallowWater)
     η = vars.grid.η                 # has a singleton step dimension for 2D models
     Φ = vars.dynamics.geopotential  # has in 2D a singleton vertical dimension
-    Φ .= planet.gravity .* η
+    Φ .= model.planet.gravity .* η
     return Φ
 end

--- a/SpeedyWeather/src/dynamics/horizontal_diffusion.jl
+++ b/SpeedyWeather/src/dynamics/horizontal_diffusion.jl
@@ -85,7 +85,7 @@ function initialize!(
     (; radius) = model.planet
 
     # Reduce diffusion time scale (=increase diffusion, always in seconds) with resolution
-    # times 1/radius because time step Δt is scaled with 1/radius
+    # divide by radius because the equations are in the radius-scaled form (see Radius scaling)
     time_scale = Second(diffusion.time_scale).value / radius * (32 / (trunc + 1))^resolution_scaling
     time_scale_div = Second(diffusion.time_scale_div).value / radius * (32 / (trunc + 1))^resolution_scaling
 
@@ -413,7 +413,7 @@ function initialize!(
     Δt = default_time_step(model.time_stepping)
     (; radius) = model.planet
 
-    # times 1/radius because time step Δt is scaled with 1/radius
+    # divide by radius because the equations are in the radius-scaled form (see Radius scaling)
     time_scale = Second(diffusion.time_scale).value / radius * (32 / (trunc + 1))^resolution_scaling
     time_scale_div = Second(diffusion.time_scale_div).value / radius * (32 / (trunc + 1))^resolution_scaling
 

--- a/SpeedyWeather/src/dynamics/horizontal_diffusion.jl
+++ b/SpeedyWeather/src/dynamics/horizontal_diffusion.jl
@@ -83,6 +83,7 @@ function initialize!(
     (; resolution_scaling, power, power_stratosphere, tapering_σ) = diffusion
     Δt = default_time_step(model.time_stepping)
     (; radius) = model.planet
+    Δt /= radius
 
     # Reduce diffusion time scale (=increase diffusion, always in seconds) with resolution
     # divide by radius because the equations are in the radius-scaled form (see Radius scaling)

--- a/SpeedyWeather/src/dynamics/horizontal_diffusion.jl
+++ b/SpeedyWeather/src/dynamics/horizontal_diffusion.jl
@@ -82,6 +82,8 @@ function initialize!(
     (; trunc, nlayers) = diffusion
     (; resolution_scaling, power, power_stratosphere, tapering_σ) = diffusion
     Δt = default_time_step(model.time_stepping)
+    
+    # radius scaling for the dynamical core as these are all precomputed arrays
     (; radius) = model.planet
     Δt /= radius
 
@@ -412,7 +414,10 @@ function initialize!(
     (; expl, impl, expl_div, impl_div) = diffusion
     (; scale, shift, power, power_div, resolution_scaling) = diffusion
     Δt = default_time_step(model.time_stepping)
+
+    # radius scaling for the dynamical core as these are all precomputed arrays
     (; radius) = model.planet
+    Δt /= radius
 
     # divide by radius because the equations are in the radius-scaled form (see Radius scaling)
     time_scale = Second(diffusion.time_scale).value / radius * (32 / (trunc + 1))^resolution_scaling

--- a/SpeedyWeather/src/dynamics/random_process.jl
+++ b/SpeedyWeather/src/dynamics/random_process.jl
@@ -82,7 +82,7 @@ function initialize!(
         model::AbstractModel,
     )
     # auto-regressive factor in the AR1 process
-    dt = model.time_stepping.Δt_sec         # in seconds
+    dt = model.time_stepping.Δt             # in seconds
     process.autoregressive_factor[] = exp(-dt / Second(process.time_scale).value)
 
     # noise factors per total wavenumber in the AR1 process

--- a/SpeedyWeather/src/dynamics/scaling.jl
+++ b/SpeedyWeather/src/dynamics/scaling.jl
@@ -12,43 +12,52 @@ the Earth's radius which is used in the dynamical core."""
     return vars
 end
 
-scale!(var::AbstractField, scale::Real) = (var .*= scale)
+function scale_tendencies!(vars::Variables, model::AbstractModel)
+    scale = vars.prognostic.scale[]
+    (; tendencies) = vars
+    TS = model.time_stepping
 
-"""$(TYPEDSIGNATURES)
-Scale the tendencies of u, v, temp, humid with scalar `scale`.
-Intended use to scale the tendencies of the parameterizations
-by the radius for the dynamical core."""
-@propagate_inbounds function scale_tendencies!(vars::NamedTuple, scale::Real)
-    haskey(vars, :u) && (vars.u .*= scale)
-    haskey(vars, :v) && (vars.v .*= scale)
-    haskey(vars, :temperature) && (vars.temperature .*= scale)
-    haskey(vars, :humidity) && (vars.humidity .*= scale)
+    # spectral
+    for varname in tendency_names(vars)
+        var = get_tendency_step(getfield(tendencies, varname), TS, DummyParameterization())
+        scale!(var, scale)
+    end
+
+    # grid
+    for varname in tendency_and_uv_names(vars)
+        var = get_tendency_step(getfield(tendencies.grid, varname), TS, DummyParameterization())
+        scale!(var, scale)
+    end
+
+    # tracers
+    for varname in tracer_tendency_names(vars)
+        var = get_tendency_step(getfield(tendencies.grid_tracers, varname), TS, DummyParameterization())
+        scale!(var, scale)
+    end
     return nothing
 end
 
-@propagate_inbounds function scale_tendencies!(ij, vars::NamedTuple, scale::Real)
-    haskey(vars, :u) && (
-        for k in eachlayer(vars.u)
-            vars.u[ij, k] *= scale
-        end
-    )
-    haskey(vars, :v) && (
-        for k in eachlayer(vars.v)
-            vars.v[ij, k] *= scale
-        end
-    )
-    haskey(vars, :temperature) && (
-        for k in eachlayer(vars.temperature)
-            vars.temperature[ij, k] *= scale
-        end
-    )
-    haskey(vars, :humidity) && (
-        for k in eachlayer(vars.humidity)
-            vars.humidity[ij, k] *= scale
-        end
-    )
+function unscale_tendencies!(vars::Variables)
+    scale = vars.prognostic.scale[]
+    (; tendencies) = vars
+
+    # spectral
+    for varname in tendency_names(vars)
+        unscale!(getfield(tendencies, varname), scale)
+    end
+
+    # grid
+    for varname in tendency_and_uv_names(vars)
+        unscale!(getfield(tendencies.grid, varname), scale)
+    end
+
+    # tracers
+    for varname in tracer_tendency_names(vars)
+        unscale!(getfield(tendencies.grid_tracers, varname), scale)
+    end
     return nothing
 end
+
 
 """$(TYPEDSIGNATURES)
 Undo the radius-scaling of vorticity and divergence from `scale_prognostic!(vars, scale::Real)`."""
@@ -62,30 +71,28 @@ function unscale!(vars::Variables)
     haskey(vars.grid, :vorticity) && (vars.grid.vorticity .*= inv_scale)
     haskey(vars.grid, :divergence) && (vars.grid.divergence .*= inv_scale)
 
-    # TODO unscale the tendencies too?
+    # also unscale tendencies
+    unscale_tendencies!(vars)
 
     progn.scale[] = 1                   # set scale back to 1=unscaled
     return vars
 end
 
-"""
-$(TYPEDSIGNATURES)
-Scale the variable `var` with scalar `scale`.
-"""
-@propagate_inbounds function scale!(
-        variable::Union{LowerTriangularArray, Field},
+"""$(TYPEDSIGNATURES)
+Scale the variable `var` with scalar `scale`."""
+@inline function scale!(
+        variable::Union{LowerTriangularArray, AbstractField},
         scale::Real
     )
-    return variable.data .*= scale
+    variable.data .*= scale
+    return variable
 end
 
-"""
-$(TYPEDSIGNATURES)
-Undo the scaling of the variable `var` with scalar `scale`.
-"""
-@propagate_inbounds function unscale!(
-        variable::Union{LowerTriangularArray, Field},
+"""$(TYPEDSIGNATURES)
+Undo the scaling of the variable `var` with scalar `scale`."""
+@inline function unscale!(
+        variable::Union{LowerTriangularArray, AbstractField},
         scale::Real
     )
-    return variable.data ./= scale
+    return scale!(variable, inv(scale))
 end

--- a/SpeedyWeather/src/dynamics/tendencies.jl
+++ b/SpeedyWeather/src/dynamics/tendencies.jl
@@ -454,6 +454,7 @@ function vordiv_tendencies!(
         time_stepping::AbstractTimeStepper,
     )
     (; f) = coriolis                            # coriolis parameter
+    scale = vars.prognostic.scale[]             # scale Coriolis on the fly as is vorticity
     Tₖ = implicit.temp_profile                  # reference temperature profile
     (; coslat⁻¹) = geometry
 
@@ -464,11 +465,11 @@ function vordiv_tendencies!(
     v = get_prognostic_step(vars.grid.v, time_stepping, DynamicalCore())
     vor = get_prognostic_step(vars.grid.vorticity, time_stepping, DynamicalCore())
     temp = get_prognostic_step(vars.grid.temperature, time_stepping, DynamicalCore())
-    
+
     # if no humidity, pass a zero scratch array to the kernel
     humid = haskey(vars.grid, :humidity) ?
         get_prognostic_step(vars.grid.humidity, time_stepping, DynamicalCore()) :
-        fill!(vars.scratch.grid.a, 0)                   
+        fill!(vars.scratch.grid.a, 0)
 
     (; dpres_dx, dpres_dy) = vars.dynamics              # zonal/meridional gradient of logarithm of surface pressure
     scratch_memory = vars.scratch.transform_memory
@@ -479,7 +480,7 @@ function vordiv_tendencies!(
     launch!(
         arch, RingGridWorkOrder, size(u_tend_grid), _vordiv_tendencies_kernel!,
         u_tend_grid, v_tend_grid, u, v, vor, temp, humid,
-        dpres_dx, dpres_dy, Tₖ, f, coslat⁻¹, whichring, atmosphere,
+        dpres_dx, dpres_dy, Tₖ, f, scale, coslat⁻¹, whichring, atmosphere,
     )
     # divergence and curl of that u, v_tend vector for vor, div tendencies
     vor_tend = get_tendency_step(vars.tendencies.vorticity, time_stepping, DynamicalCore())
@@ -503,19 +504,19 @@ end
         vor_grid,               # Input: relative vorticity
         temp_grid,              # Input: temperature anomaly
         humid_grid,             # Input: humidity
-        dpres_dx,                 # Input: zonal gradient of log surface pressure
-        dpres_dy,                 # Input: meridional gradient of log surface pressure
+        dpres_dx,               # Input: zonal gradient of log surface pressure
+        dpres_dy,               # Input: meridional gradient of log surface pressure
         Tₖ,                     # Input: reference temperature profile
-        f,              # Input: coriolis parameter
-        coslat⁻¹,       # Input: 1/cos(latitude) for scaling
-        whichring,      # Input: mapping from grid point to latitude ring
+        f,                      # Input: coriolis parameter
+        scale,                  # Input: Scaling of vorticity, apply to Coriolis on the fly too
+        coslat⁻¹,               # Input: 1/cos(latitude) for scaling
+        whichring,              # Input: mapping from grid point to latitude ring
         atmosphere,             # Input: atmosphere for R_dry and μ_virt_temp
     )
     ij, k = @index(Global, NTuple)
     j = whichring[ij]           # latitude ring index for this grid point
     coslat⁻¹j = coslat⁻¹[j]     # get coslat⁻¹ for this latitude
-    f_j = f[j]                  # coriolis parameter for this latitude
-
+    f_j = f[j] * scale          # coriolis parameter for this latitude, scaled
     ω = vor_grid[ij, k] + f_j   # absolute vorticity
 
     # compute virtual temperature on the fly, temp_grid is anomaly
@@ -591,7 +592,7 @@ function temperature_tendency!(
 
     # use scratch array with zeros in case humidity doesn't exist
     humid = haskey(vars.grid, :humidity) ?
-        get_prognostic_step(vars.grid.humidity, time_stepping, DynamicalCore()) : 
+        get_prognostic_step(vars.grid.humidity, time_stepping, DynamicalCore()) :
         fill!(vars.scratch.grid.a, 0)
 
     (; pres_flux, pres_flux_sum_above, div_sum_above) = vars.dynamics
@@ -818,6 +819,7 @@ function vorticity_flux_curldiv!(
     )
 
     (; f) = model.coriolis
+    scale = vars.prognostic.scale[]     # used to scale Coriolis f on the fly, as it's being added to a scaled vorticity
     (; coslat⁻¹) = model.geometry
 
     u_tend_grid = get_tendency_step(vars.tendencies.grid.u, model.time_stepping, DynamicalCore(), model)
@@ -831,7 +833,7 @@ function vorticity_flux_curldiv!(
 
     launch!(
         architecture(u), RingGridWorkOrder, size(u), _vorticity_flux_kernel!,
-        u_tend_grid, v_tend_grid, u, v, vor, f, coslat⁻¹, whichring
+        u_tend_grid, v_tend_grid, u, v, vor, f, scale, coslat⁻¹, whichring
     )
 
     # divergence and curl of that u, v_tend vector for vor, div tendencies
@@ -853,17 +855,17 @@ function vorticity_flux_curldiv!(
 end
 
 @kernel inbounds = true function _vorticity_flux_kernel!(
-        u_tend_grid, v_tend_grid, u, v, vor, f, coslat⁻¹, whichring
+        u_tend_grid, v_tend_grid, u, v, vor, f, scale, coslat⁻¹, whichring
     )
     # Get indices
     ij, k = @index(Global, NTuple)
     j = whichring[ij]
 
     # Get the coriolis parameter and cosine latitude factor for this latitude
-    f_j = f[j]
+    f_j = f[j] * scale              # scaled as is vorticity
     coslat⁻¹j = coslat⁻¹[j]
 
-    # Calculate absolute vorticity
+    # Calculate absolute vorticity, scale f as is vorticity too on the fly
     ω = vor[ij, k] + f_j
 
     # Update tendencies

--- a/SpeedyWeather/src/dynamics/tendencies.jl
+++ b/SpeedyWeather/src/dynamics/tendencies.jl
@@ -6,29 +6,26 @@ function dynamics_tendencies!(
     )
     forcing!(vars, model)               # = (Fᵤ, Fᵥ) forcing for u, v
     drag!(vars, model)                  # drag term for u, v
+    scale_tendencies!(vars, model)      # dynamical core uses a scaled time step, Δt/radius
     vorticity_flux!(vars, model)        # = ∇×(v(ζ+f) + Fᵤ, -u(ζ+f) + Fᵥ)
     tracer_advection!(vars, model)
     return nothing
 end
 
-"""
-$(TYPEDSIGNATURES)
+"""$(TYPEDSIGNATURES)
 Calculate all tendencies for the ShallowWaterModel."""
 function dynamics_tendencies!(
         vars::Variables,
         model::ShallowWater,
     )
-    (; planet, atmosphere, orography) = model
-    (; spectral_transform, geometry) = model
-
     forcing!(vars, model)               # = (Fᵤ, Fᵥ, Fₙ) forcing for u, v, η
     drag!(vars, model)                  # drag term for u, v
+    scale_tendencies!(vars, model)      # dynamical core uses a scaled time step, Δt/radius
 
     # = ∇×(v(ζ+f) + Fᵤ, -u(ζ+f) + Fᵥ), tendency for vorticity
     # = ∇⋅(v(ζ+f) + Fᵤ, -u(ζ+f) + Fᵥ), tendency for divergence
     vorticity_flux!(vars, model)
-
-    geopotential!(vars, planet)         # geopotential Φ = gη in shallow water
+    geopotential!(vars, model)          # geopotential Φ = gη in shallow water
     bernoulli_potential!(vars, model)   # = -∇²(E+Φ), tendency for divergence
 
     # = -∇⋅(uh, vh), tendency for interface displacement η
@@ -48,6 +45,7 @@ function dynamics_tendencies!(
     )
     forcing!(vars, model)
     drag!(vars, model)
+    scale_tendencies!(vars, model)
 
     (; orography, geometry, spectral_transform, geopotential, atmosphere, implicit, time_stepping) = model
 

--- a/SpeedyWeather/src/output/feedback.jl
+++ b/SpeedyWeather/src/output/feedback.jl
@@ -59,7 +59,7 @@ function initialize!(feedback::Feedback, variables::Variables, model::AbstractMo
 
     # hack: redefine element in global constant dt_in_sec
     # used to pass on the time step to ProgressMeter.speedstring
-    FEEDBACK_DT_IN_SEC[] = model.time_stepping.Δt_sec
+    FEEDBACK_DT_IN_SEC[] = model.time_stepping.Δt
     FEEDBACK_TIME[] = clock.time
 
     # reset those to default (-1 not shown)
@@ -274,7 +274,7 @@ function initialize!(progress_txt::ProgressTxt, vars, model)
     write(file, s * "\n")
     write(file, "Integrating:\n")
     write(file, "$SG\n")
-    write(file, "Time: $days days at Δt = $(L.Δt_sec)s\n")
+    write(file, "Time: $days days at Δt = $(L.Δt)s\n")
     model.output.active && write(file, "\nAll data will be stored in $run_path\n")
     model.output.active || write(file, "\nNo output will be written (output=false)\n")
     progress_txt.file = file

--- a/SpeedyWeather/src/output/writers/general.jl
+++ b/SpeedyWeather/src/output/writers/general.jl
@@ -173,7 +173,7 @@ function output!(
     # unscale if variable.unscale == true and exists
     if hasproperty(variable, :unscale)
         if variable.unscale
-            scale!(var, inv(simulation.variables.prognostic.scale[]))
+            unscale!(var, simulation.variables.prognostic.scale[])
         end
     end
 

--- a/SpeedyWeather/src/output/writers/output_writer_core.jl
+++ b/SpeedyWeather/src/output/writers/output_writer_core.jl
@@ -69,7 +69,7 @@ function initialize!(
     # OUTPUT FREQUENCY, recalculate interval after rounding
     f = round(Int, Millisecond(output.interval).value / model.time_stepping.Δt_millisec.value)
     core.output_every_n_steps = max(1, f)
-    output.interval = Second(round(Int, core.output_every_n_steps * model.time_stepping.Δt_sec))
+    output.interval = Second(round(Int, core.output_every_n_steps * model.time_stepping.Δt))
 
     # RESET COUNTERS
     core.output_counter = 1             # start at 1 for writing the initial conditions

--- a/SpeedyWeather/src/parameterizations/convection.jl
+++ b/SpeedyWeather/src/parameterizations/convection.jl
@@ -37,7 +37,7 @@ and relaxes current vertical profiles to the adjusted references."""
     σ_half = geometry.σ_levels_half
     Δσ = geometry.σ_levels_thick
     nlayers = length(σ)
-    Δt = time_stepping.Δt_sec
+    (; Δt) = model.time_stepping                            # time step in [s]
 
     # use previous time step for more stable calculations
     temp = get_prognostic_step(vars.grid.temperature, time_stepping, convection)
@@ -45,7 +45,7 @@ and relaxes current vertical profiles to the adjusted references."""
     geopotential = vars.dynamics.geopotential
     temp_tend = get_tendency_step(vars.tendencies.grid.temperature, time_stepping, convection)
     humid_tend = get_tendency_step(vars.tendencies.grid.humidity, time_stepping, convection)
-    pₛ = vars.parameterizations.surface_pressure[ij]          # surface pressure [Pa]
+    pₛ = vars.parameterizations.surface_pressure[ij]        # surface pressure [Pa]
     NF = eltype(temp)
 
     # thermodynamics

--- a/SpeedyWeather/src/parameterizations/land/snow.jl
+++ b/SpeedyWeather/src/parameterizations/land/snow.jl
@@ -43,14 +43,14 @@ function timestep!(
         model::PrimitiveEquation,
     )
 
-    Δt = model.time_stepping.Δt_sec
+    (; Δt) = model.time_stepping                            # time step [s]
     (; snow_depth) = vars.prognostic.land                   # in equivalent liquid water height [m]
     (; soil_temperature) = vars.prognostic.land
     (; land_fraction) = model.land_sea_mask
 
     # Some thermodynamics needed by snow
     ρ_water = model.atmosphere.water_density                # water density [kg/m³]
-    Lᵢ = model.atmosphere.latent_heat_fusion                  # latent heat of fusion
+    Lᵢ = model.atmosphere.latent_heat_fusion                # latent heat of fusion
     cₛ = model.land.thermodynamics.heat_capacity_dry_soil
     z₁ = model.land.geometry.layer_thickness[1]
     (; melting_threshold, snow_depth_cap) = snow

--- a/SpeedyWeather/src/parameterizations/land/soil_moisture.jl
+++ b/SpeedyWeather/src/parameterizations/land/soil_moisture.jl
@@ -211,7 +211,7 @@ function timestep!(
         model::PrimitiveEquation,
     )
     (; soil_moisture) = vars.prognostic.land
-    Δt = model.time_stepping.Δt_sec
+    (; Δt) = model.time_stepping                            # time step in [s]
     ρ = model.atmosphere.water_density
     (; land_fraction) = model.land_sea_mask
 

--- a/SpeedyWeather/src/parameterizations/land/soil_temperature.jl
+++ b/SpeedyWeather/src/parameterizations/land/soil_temperature.jl
@@ -223,7 +223,7 @@ function timestep!(
     soil_moisture = haskey(vars.prognostic.land, :soil_moisture) ? vars.prognostic.land.soil_moisture : nothing
     Lᵥ = latent_heat_condensation(model.atmosphere)
     Lᵢ = latent_heat_sublimation(model.atmosphere)
-    Δt = model.time_stepping.Δt_sec
+    (; Δt) = model.time_stepping                                # time step in [s]
 
     (; land_fraction) = model.land_sea_mask
     (; thermodynamics, geometry) = model.land

--- a/SpeedyWeather/src/parameterizations/large_scale_condensation.jl
+++ b/SpeedyWeather/src/parameterizations/large_scale_condensation.jl
@@ -70,7 +70,7 @@ large-scale precipitation vertically for output."""
 
     # precompute scaling constants to minimize divisions (used to convert between humidity [kg/kg] and precipitation [m])           
     pₛ = vars.parameterizations.surface_pressure[ij]    # surface pressure [Pa]
-    (; Δt_sec) = time_stepping                          # time step [s]
+    (; Δt) = time_stepping                              # time step [s]
     σ = geometry.σ_levels_full                          # vertical sigma coordinate [1]
     Δσ = geometry.σ_levels_thick                        # layer thickness in sigma coordinates
     ρ = atmosphere.water_density                        # air density [kg/m³]
@@ -102,7 +102,7 @@ large-scale precipitation vertically for output."""
 
             # 0. convert between humidity tendency [kg/kg/s] and precipitation amount [m] or rate [m/s]
             Δp_gρ = Δσ[k] * pₛ_gρ                           # pressure thickness of layer Δp times 1/g/ρ [m]
-            Δp_Δtgρ = Δp_gρ / Δt_sec                        # pressure thickness of layer Δp times 1/Δt/g/ρ [m/s]
+            Δp_Δtgρ = Δp_gρ / Δt                            # pressure thickness of layer Δp times 1/Δt/g/ρ [m/s]
             Δtgρ_Δp = inv(Δp_Δtgρ)                          # [s/m]
 
             # 1. Melting of snow from layer above
@@ -128,9 +128,9 @@ large-scale precipitation vertically for output."""
             # Solve for melting of snow, condensation, reevaporation (and possibly sublimation) implicitly in time
             # implicit correction, Frierson et al. 2006 eq. (21)
             # derivative of qsat wrt to temp
-            T = temp[ij, k] + Δt_sec * δT                     # use temperature minus latent heat for melting in gradient
+            T = temp[ij, k] + Δt * δT                       # use temperature minus latent heat for melting in gradient
             dqsat_dT = sat_humid_k * relative_humidity_threshold * Lᵥ_cₚ / (Rᵥ * T^2)
-            δq /= ((1 + Lᵥ_cₚ * dqsat_dT) * time_scale * Δt_sec)
+            δq /= ((1 + Lᵥ_cₚ * dqsat_dT) * time_scale * Δt)
             δT = -Lᵥ_cₚ * δq                                # latent heat release for enthalpy conservation
 
             # If there is large-scale condensation at a level higher (i.e. smaller k) than
@@ -162,8 +162,8 @@ large-scale precipitation vertically for output."""
     snow_flux_down = max(snow_flux_down, 0)
 
     # precipitation from rain/snow [m] during time step whatever is fluxed out
-    vars.parameterizations.rain_large_scale[ij] += Δt_sec * rain_flux_down
-    vars.parameterizations.snow_large_scale[ij] += Δt_sec * snow_flux_down
+    vars.parameterizations.rain_large_scale[ij] += Δt * rain_flux_down
+    vars.parameterizations.snow_large_scale[ij] += Δt * snow_flux_down
 
     # and the rain/snow fall rate [m/s]
     vars.parameterizations.rain_rate_large_scale[ij] = rain_flux_down

--- a/SpeedyWeather/src/parameterizations/ocean.jl
+++ b/SpeedyWeather/src/parameterizations/ocean.jl
@@ -331,7 +331,7 @@ function timestep!(vars::Variables, ocean_model::SlabOcean, model::PrimitiveEqua
 
     Lᵥ = latent_heat_condensation(model.atmosphere)
     C₀ = ocean_model.heat_capacity_mixed_layer
-    Δt = model.time_stepping.Δt_sec
+    (; Δt) = model.time_stepping
     Δt_C₀ = Δt / C₀
 
     (; land_fraction) = model.land_sea_mask

--- a/SpeedyWeather/src/parameterizations/radiation/shortwave_transmissivity.jl
+++ b/SpeedyWeather/src/parameterizations/radiation/shortwave_transmissivity.jl
@@ -46,8 +46,8 @@ $(TYPEDFIELDS)."""
     "[OPTION] Zenith correction exponent (SPEEDY nzen)"
     @param zenith_exponent::NF = 2 (bounds = Nonnegative,)
 
-    "[OPTION] Absorptivity of dry air [per 10^5 Pa]"
     # Weighted visible + near-IR: 0.95*0.033 + 0.05*0.0 = 0.03135 (SPEEDY absdry, fband weights)
+    "[OPTION] Absorptivity of dry air [per 10^5 Pa]"
     @param absorptivity_dry_air::NF = 0.03135 (bounds = Nonnegative,)
 
     "[OPTION] Constant aerosol concentration?"
@@ -66,8 +66,8 @@ $(TYPEDFIELDS)."""
     "[OPTION] Base cloud absorptivity [per kg/kg per 10^5 Pa]"
     @param absorptivity_cloud_base::NF = 10 (bounds = Nonnegative,)
 
-    "[OPTION] Maximum cloud absorptivity [per 10^5 Pa]"
     # Weighted one-band scaling: 0.95*0.15 = 0.1425 → rounded to 0.14 (SPEEDY abscl2)
+    "[OPTION] Maximum cloud absorptivity [per 10^5 Pa]"
     @param absorptivity_cloud_limit::NF = 0.14 (bounds = Nonnegative,)
 end
 

--- a/SpeedyWeather/src/parameterizations/sea_ice.jl
+++ b/SpeedyWeather/src/parameterizations/sea_ice.jl
@@ -51,7 +51,7 @@ function timestep!(vars::Variables, sea_ice_model::ThermodynamicSeaIce, model::P
     haskey(vars.prognostic.ocean, :sea_surface_temperature) || return nothing
     sst = vars.prognostic.ocean.sea_surface_temperature
 
-    Δt = model.time_stepping.Δt_sec
+    (; Δt) = model.time_stepping
     (; land_fraction) = model.land_sea_mask
 
     m = sea_ice_model.melt_rate             # melt rate [m²/m²/s/K]

--- a/SpeedyWeather/src/parameterizations/tendencies.jl
+++ b/SpeedyWeather/src/parameterizations/tendencies.jl
@@ -51,9 +51,6 @@ end
 
     # manually unroll loop over all parameterizations (NamedTuple iteration not GPU-compatible)
     column_parameterizations!(ij, vars, parameterizations, model)
-
-    # tendencies have to be scaled by the radius for the dynamical core
-    scale_tendencies!(ij, vars.tendencies.grid, model.planet.radius)
 end
 
 # Use @generated to unroll NamedTuple iteration at compile time for GPU compatibility
@@ -70,9 +67,6 @@ end
 # this yields a more contiguous memory access pattern on CPU
 function column_parameterizations_cpu!(vars, model)
     _column_parameterizations_cpu!(vars, get_parameterizations(model), model)
-
-    # tendencies have to be scaled by the radius for the dynamical core
-    @inbounds scale_tendencies!(vars.tendencies.grid, model.planet.radius)
     return nothing
 end
 

--- a/SpeedyWeather/src/time_stepping/implicit/implicit_primitive_equations.jl
+++ b/SpeedyWeather/src/time_stepping/implicit/implicit_primitive_equations.jl
@@ -88,9 +88,10 @@ function reinitialize!(
     (; time_stepping, geometry, geopotential, atmosphere, adiabatic_conversion) = model
     Δt = time_step(time_stepping, vars.prognostic.clock) 
     implicit.Δt[] == Δt && return nothing                   # if time step has not changed no need to reinitialize
+    scale = vars.prognostic.scale[]                         # implicit solver needs to be initialized with scaled time step
     Tₖ = vars.dynamics.average_temperature_profile
-    scale = vars.prognostic.scale[]
-    initialize!(implicit, Δt, scale, Tₖ, geometry, geopotential, atmosphere, adiabatic_conversion)
+    initialize!(implicit, Δt / scale, Tₖ, geometry, geopotential, atmosphere, adiabatic_conversion)
+    implicit.Δt[] = Δt
     return nothing
 end
 
@@ -98,8 +99,7 @@ end
 Initialize the implicit terms for the PrimitiveEquation models."""
 function initialize!(
         implicit::ImplicitPrimitiveEquation,
-        Δt::Real,                                           # the time step [s]
-        scale::Real,                                        # scale of prognostic variables, apply to time step on the fly
+        Δt::Real,                                           # the time step [s], scaled
         temp_average::AbstractVector,                       # average vertical temperature profile to construct the operators
         geometry::AbstractGeometry,
         geopotential::AbstractGeopotential,
@@ -158,8 +158,7 @@ function initialize!(
     # to obtain δD first, and then δT and δlnps through substitution
 
     @assert 0.5 <= implicit.centering <= 1 "Centering coefficient must be between 0.5 (centred implicit) and 1 (backward implicit)"
-    implicit.Δt[] = Δt                          # store the time step used for initialization to check for changes later
-    ξ = implicit.centering * Δt / scale         # 2Δt for leapfrog, but = Δt, Δ/2 in first_timesteps!
+    ξ = implicit.centering * Δt                 # 2Δt for leapfrog, but = Δt, Δ/2 in first_timesteps!
 
     # DIVERGENCE OPERATORS (called g in Hoskins and Simmons 1975, eq 11 and Appendix 1)
     @inbounds for k in 1:nlayers                # vertical geopotential integration as matrix operator

--- a/SpeedyWeather/src/time_stepping/implicit/implicit_primitive_equations.jl
+++ b/SpeedyWeather/src/time_stepping/implicit/implicit_primitive_equations.jl
@@ -248,8 +248,9 @@ function implicit_correction!(
     (; S⁻¹, R, U, L, W, nlayers) = implicit
     
     # new implicit timestep ξ = α*dt = 2αΔt (for leapfrog)
+    # dynamical core uses scaled time step, scale on the fly
     Δt = time_step(time_stepping, vars.prognostic.clock)       
-    ξ = implicit.centering * Δt
+    ξ = implicit.centering * Δt / vars.prognostic.scale[]
 
     temp_tend = get_tendency_step(vars.tendencies.temperature, time_stepping, implicit)
     pres_tend = get_tendency_step(vars.tendencies.pressure, time_stepping, implicit)

--- a/SpeedyWeather/src/time_stepping/implicit/implicit_primitive_equations.jl
+++ b/SpeedyWeather/src/time_stepping/implicit/implicit_primitive_equations.jl
@@ -23,7 +23,7 @@ $(TYPEDFIELDS)"""
     "[OPTION] Time-step coefficient: 0.5 = Crank-Nicolson, 1=backward Euler"
     centering::NF = 1.0
 
-    "[DERIVED] (Scaled) time step used to initialize. Used to check whether time step has changed and reinitialization is needed."
+    "[DERIVED] Time step [s] used to initialize. Used to check whether time step has changed and reinitialization is needed."
     Δt::Base.RefValue{NF} = Ref(zero(NF))
 
     # PRECOMPUTED ARRAYS, to be initialized with initialize!
@@ -89,7 +89,8 @@ function reinitialize!(
     Δt = time_step(time_stepping, vars.prognostic.clock) 
     implicit.Δt[] == Δt && return nothing                   # if time step has not changed no need to reinitialize
     Tₖ = vars.dynamics.average_temperature_profile
-    initialize!(implicit, Δt, Tₖ, geometry, geopotential, atmosphere, adiabatic_conversion)
+    scale = vars.prognostic.scale[]
+    initialize!(implicit, Δt, scale, Tₖ, geometry, geopotential, atmosphere, adiabatic_conversion)
     return nothing
 end
 
@@ -97,7 +98,8 @@ end
 Initialize the implicit terms for the PrimitiveEquation models."""
 function initialize!(
         implicit::ImplicitPrimitiveEquation,
-        Δt::Real,                                           # the scaled time step radius*dt
+        Δt::Real,                                           # the time step [s]
+        scale::Real,                                        # scale of prognostic variables, apply to time step on the fly
         temp_average::AbstractVector,                       # average vertical temperature profile to construct the operators
         geometry::AbstractGeometry,
         geopotential::AbstractGeopotential,
@@ -156,8 +158,8 @@ function initialize!(
     # to obtain δD first, and then δT and δlnps through substitution
 
     @assert 0.5 <= implicit.centering <= 1 "Centering coefficient must be between 0.5 (centred implicit) and 1 (backward implicit)"
-    ξ = implicit.centering * Δt                 # 2Δt for leapfrog, but = Δt, Δ/2 in first_timesteps!
     implicit.Δt[] = Δt                          # store the time step used for initialization to check for changes later
+    ξ = implicit.centering * Δt / scale         # 2Δt for leapfrog, but = Δt, Δ/2 in first_timesteps!
 
     # DIVERGENCE OPERATORS (called g in Hoskins and Simmons 1975, eq 11 and Appendix 1)
     @inbounds for k in 1:nlayers                # vertical geopotential integration as matrix operator

--- a/SpeedyWeather/src/time_stepping/implicit/implicit_shallow_water.jl
+++ b/SpeedyWeather/src/time_stepping/implicit/implicit_shallow_water.jl
@@ -55,7 +55,7 @@ function implicit_correction!(
     
     # new implicit timestep ξ = α*dt = 2αΔt (for leapfrog)
     Δt = time_step(time_stepping, vars.prognostic.clock)       
-    ξ = implicit.centering * Δt
+    ξ = implicit.centering * Δt / vars.prognostic.scale[]   # scale time step on the fly
     
     # Get precomputed l_indices from the spectrum
     l_indices = div_tend.spectrum.l_indices
@@ -110,7 +110,7 @@ function implicit_correction!(
     # implicit timestep ξ = α*Δt, depending on centering (0.5 Crank Nicolson, 1 backward Euler)
     (; Δt) = time_stepping    
     w = weight_coefficient(time_stepping, vars.prognostic.clock)
-    ξ = w * implicit.centering * Δt
+    ξ = w * implicit.centering * Δt / vars.prognostic.scale[]
 
     # use Hotta et al. 2016 notation for current tendency F and previous (averaged) tendency G
     F_div, G_div = get_steps(vars.tendencies.divergence)

--- a/SpeedyWeather/src/time_stepping/steppers/general.jl
+++ b/SpeedyWeather/src/time_stepping/steppers/general.jl
@@ -55,22 +55,20 @@ and disables adjustment to output frequency.
 `set!` can be used before or after `initialize!(model)`."""
 function set!(
         L::AbstractTimeStepper,
-        Δt::Period;                         # unscaled time step in Second, Minute, ...
-        radius = L.Δt_sec/L.Δt              # get radius from scaled time step
+        Δt::Period,
     )
     # if set! is used before `initialize!(model)` then the recalculation of
     # Δt_at_T31 will make sure the desired time step is used when initialize!(model.time_stepping, ...) happens
     # if set! is used after `initialize!(model)` then all fields are set consistently
 
     # get truncation/resolution factor implicitly from Δt at this resolution vs default T31 resolution
-    resolution_factor = L.Δt_sec / Second(L.Δt_at_T31).value
+    resolution_factor = L.Δt / Second(L.Δt_at_T31).value
 
     L.Δt_millisec = Millisecond(Δt)         # recalculate all Δt fields
-    L.Δt_sec = Millisecond(L.Δt_millisec).value / 1000
-    L.Δt = L.Δt_sec / radius
+    L.Δt = Millisecond(L.Δt_millisec).value / 1000
 
     # recalculate the default time step at resolution T31 to be consistent
-    L.Δt_at_T31 = Second(round(Int, L.Δt_sec * resolution_factor))
+    L.Δt_at_T31 = Second(round(Int, L.Δt * resolution_factor))
 
     # given Δt was manually set disallow adjustment to output frequency
     L.adjust_with_output = false
@@ -78,7 +76,7 @@ function set!(
 end
 
 # also allow for keyword arguments
-set!(L::AbstractTimeStepper; Δt::Period, kwargs...) = set!(L, Δt; kwargs...)
+set!(L::AbstractTimeStepper; Δt::Period) = set!(L, Δt)
 
 function calculate_Δt!(L::AbstractTimeStepper, model::AbstractModel)
     (; trunc) = model.spectral_grid
@@ -87,8 +85,7 @@ function calculate_Δt!(L::AbstractTimeStepper, model::AbstractModel)
 
     # take radius from planet and recalculate time step and possibly adjust with output dt
     L.Δt_millisec = get_Δt_millisec(L.Δt_at_T31, trunc, radius, L.adjust_with_output, interval)
-    L.Δt_sec = L.Δt_millisec.value / 1000
-    L.Δt = L.Δt_sec / radius
+    L.Δt = L.Δt_millisec.value / 1000
 
     # check how time steps from time integration and output align
     if L.adjust_with_output

--- a/SpeedyWeather/src/time_stepping/steppers/leapfrog.jl
+++ b/SpeedyWeather/src/time_stepping/steppers/leapfrog.jl
@@ -207,10 +207,10 @@ function update_prognostic!(
         var::AbstractArray,
         tendency::AbstractArray,
         clock::Clock,
-        scale::Real,
         time_stepping::Leapfrog,
         implicit::Union{Nothing, AbstractImplicit},
         ::AbstractModel,
+        scale::Real = 1,
     )
     Δt = time_step(time_stepping, clock)
     Δt /= oftype(Δt, scale)                         # scale time step on the fly *1/radius for atmospheric variables

--- a/SpeedyWeather/src/time_stepping/steppers/leapfrog.jl
+++ b/SpeedyWeather/src/time_stepping/steppers/leapfrog.jl
@@ -207,12 +207,13 @@ function update_prognostic!(
         var::AbstractArray,
         tendency::AbstractArray,
         clock::Clock,
-        scale::Number,
+        scale::Real,
         time_stepping::Leapfrog,
         implicit::Union{Nothing, AbstractImplicit},
         ::AbstractModel,
     )
-    Δt = time_step(time_stepping, clock) / scale    # scale time step on the fly *1/radius for atmospheric variables
+    Δt = time_step(time_stepping, clock)
+    Δt /= oftype(Δt, scale)                         # scale time step on the fly *1/radius for atmospheric variables
     lf = prognostic_step(time_stepping, clock)      # leapfrog prognostic step index
     var_old, var_new = get_steps(var)
     var_lf = get_step(var, lf)                      # view on either t or t+dt to dis/enable Williams filter

--- a/SpeedyWeather/src/time_stepping/steppers/leapfrog.jl
+++ b/SpeedyWeather/src/time_stepping/steppers/leapfrog.jl
@@ -21,13 +21,10 @@ mutable struct Leapfrog{NF, S, B, MS} <: AbstractLeapfrog
     Δt_millisec::MS
 
     "[DERIVED] Time step Δt [s] at specified resolution"
-    Δt_sec::NF
-
-    "[DERIVED] Time step Δt [s/m] at specified resolution, scaled by 1/radius"
     Δt::NF
 end
 
-Adapt.adapt_structure(to, L::Leapfrog) = Adapt.adapt_structure(to, LeapfrogCore(L.Δt_millisec, L.Δt_sec, L.Δt))
+Adapt.adapt_structure(to, L::Leapfrog) = Adapt.adapt_structure(to, LeapfrogCore(L.Δt_millisec, L.Δt))
 
 # HOW MANY STEPS DO VARIABLES NEED?
 # leapfrogging always needs 2 steps in spectral
@@ -115,14 +112,9 @@ function move_prognostic_grid_variables_back!(
         var_old, var_new = get_steps(getfield(grid.tracers, varname))
         var_old .= var_new
     end
-    for varname in ocean_tendency_names(vars)
-        var_old, var_new = get_steps(getfield(grid.ocean, varname))
-        var_old .= var_new
-    end
-    for varname in land_tendency_names(vars)
-        var_old, var_new = get_steps(getfield(grid.land, varname))
-        var_old .= var_new
-    end
+    # does not have to be done for ocean/land as they don't have spectral variables
+    # the grid variables are already in prognostic and the time stepper takes care
+    # of moving them back during the update
     return nothing
 end
 
@@ -140,9 +132,6 @@ struct LeapfrogCore{NF, MS} <: AbstractLeapfrog
     Δt_millisec::MS
 
     "[DERIVED] Time step Δt [s] at specified resolution"
-    Δt_sec::NF
-
-    "[DERIVED] Time step Δt [s/m] at specified resolution, scaled by 1/radius"
     Δt::NF
 end
 
@@ -157,17 +146,15 @@ function Leapfrog(
         adjust_with_output = true,
         robert_filter = 0.1,
         williams_filter = 0.53,
-        radius = DEFAULT_RADIUS,
     )
     (; NF, trunc) = spectral_grid
 
     # compute time step
     Δt_millisec::Millisecond = get_Δt_millisec(Second(Δt_at_T31), trunc, DEFAULT_RADIUS, adjust_with_output)
-    Δt_sec::NF = Δt_millisec.value / 1000
-    Δt::NF = Δt_sec / radius
+    Δt::NF = Δt_millisec.value / 1000
 
     return Leapfrog(
-        Second(Δt_at_T31), adjust_with_output, NF(robert_filter), NF(williams_filter), Δt_millisec, Δt_sec, Δt,
+        Second(Δt_at_T31), adjust_with_output, NF(robert_filter), NF(williams_filter), Δt_millisec, Δt,
     )
 end
 
@@ -220,14 +207,15 @@ function update_prognostic!(
         var::AbstractArray,
         tendency::AbstractArray,
         clock::Clock,
+        scale::Number,
         time_stepping::Leapfrog,
         implicit::Union{Nothing, AbstractImplicit},
         ::AbstractModel,
     )
-    Δt = time_step(time_stepping, clock)
-    lf = prognostic_step(time_stepping, clock)  # leapfrog prognostic step index
+    Δt = time_step(time_stepping, clock) / scale    # scale time step on the fly *1/radius for atmospheric variables
+    lf = prognostic_step(time_stepping, clock)      # leapfrog prognostic step index
     var_old, var_new = get_steps(var)
-    var_lf = get_step(var, lf)                  # view on either t or t+dt to dis/enable Williams filter
+    var_lf = get_step(var, lf)                      # view on either t or t+dt to dis/enable Williams filter
     var_tend = get_tendency_step(tendency, time_stepping, time_stepping)
 
     @boundscheck lf == 1 || lf == 2 || throw(BoundsError())

--- a/SpeedyWeather/src/time_stepping/steppers/ncycle_lorenz.jl
+++ b/SpeedyWeather/src/time_stepping/steppers/ncycle_lorenz.jl
@@ -146,10 +146,10 @@ function update_prognostic!(
         var::AbstractArray,
         tendency::AbstractArray,
         clock::Clock,
-        scale::Real,
         time_stepping::NCycleLorenz,
         implicit::Union{Nothing, AbstractImplicit},
         ::AbstractModel,
+        scale::Real = 1,
     )
     (; Δt) = time_stepping
     Δt /= oftype(Δt, scale)     # scale on the fly

--- a/SpeedyWeather/src/time_stepping/steppers/ncycle_lorenz.jl
+++ b/SpeedyWeather/src/time_stepping/steppers/ncycle_lorenz.jl
@@ -49,13 +49,10 @@ mutable struct NCycleLorenz{NF, V, IntType, S, MS, B} <: AbstractNCycleLorenz
     Δt_millisec::MS
 
     "[DERIVED] Time step Δt [s] at specified resolution"
-    Δt_sec::NF
-
-    "[DERIVED] Time step Δt [s/m] at specified resolution, scaled by 1/radius"
     Δt::NF
 end
 
-Adapt.adapt_structure(to, L::NCycleLorenz) = Adapt.adapt_structure(to, NCycleLorenzCore(L.Δt_millisec, L.Δt_sec, L.Δt))
+Adapt.adapt_structure(to, L::NCycleLorenz) = Adapt.adapt_structure(to, NCycleLorenzCore(L.Δt_millisec, L.Δt))
 
 prognostic_steps(::NCycleLorenz) = 1
 tendency_grid_steps(::NCycleLorenz) = 1     # the grid tendencies are only for F though, the G term only needs storing in spectral space
@@ -78,7 +75,6 @@ end
 
 struct NCycleLorenzCore{NF, MS} <: AbstractNCycleLorenz
     Δt_millisec::MS
-    Δt_sec::NF
     Δt::NF
 end
 
@@ -92,16 +88,14 @@ function NCycleLorenz(
         variant = NCycleLorenzA(),
         Δt_at_T31 = Minute(30),
         adjust_with_output = true,
-        radius = DEFAULT_RADIUS,
     )
     (; NF, trunc) = spectral_grid
 
     # compute time step
     Δt_millisec::Millisecond = get_Δt_millisec(Second(Δt_at_T31), trunc, DEFAULT_RADIUS, adjust_with_output)
-    Δt_sec::NF = Δt_millisec.value / 1000
-    Δt::NF = Δt_sec / radius
+    Δt::NF = Δt_millisec.value / 1000
 
-    return NCycleLorenz(steps, variant, Second(Δt_at_T31), adjust_with_output, Δt_millisec, Δt_sec, Δt)
+    return NCycleLorenz(steps, variant, Second(Δt_at_T31), adjust_with_output, Δt_millisec, Δt)
 end
 
 """$(TYPEDSIGNATURES)
@@ -152,11 +146,12 @@ function update_prognostic!(
         var::AbstractArray,
         tendency::AbstractArray,
         clock::Clock,
+        scale::Number,
         time_stepping::NCycleLorenz,
         implicit::Union{Nothing, AbstractImplicit},
         ::AbstractModel,
     )
-    (; Δt) = time_stepping
+    Δt = time_stepping.Δt / scale       # scale on the fly
     w = weight_coefficient(time_stepping, clock)
 
     # with an implicit solver the tendency_average_kernel! has to be computed

--- a/SpeedyWeather/src/time_stepping/steppers/ncycle_lorenz.jl
+++ b/SpeedyWeather/src/time_stepping/steppers/ncycle_lorenz.jl
@@ -146,12 +146,14 @@ function update_prognostic!(
         var::AbstractArray,
         tendency::AbstractArray,
         clock::Clock,
-        scale::Number,
+        scale::Real,
         time_stepping::NCycleLorenz,
         implicit::Union{Nothing, AbstractImplicit},
         ::AbstractModel,
     )
-    Δt = time_stepping.Δt / scale       # scale on the fly
+    (; Δt) = time_stepping
+    Δt /= oftype(Δt, scale)     # scale on the fly
+    
     w = weight_coefficient(time_stepping, clock)
 
     # with an implicit solver the tendency_average_kernel! has to be computed

--- a/SpeedyWeather/src/time_stepping/steppers/ncycle_lorenz.jl
+++ b/SpeedyWeather/src/time_stepping/steppers/ncycle_lorenz.jl
@@ -153,14 +153,9 @@ function update_prognostic!(
     )
     (; Δt) = time_stepping
     Δt /= oftype(Δt, scale)     # scale on the fly
-    
     w = weight_coefficient(time_stepping, clock)
 
-    # with an implicit solver the tendency_average_kernel! has to be computed
-    # before the implicit solver, so the responsibility is left therein
-    # and execute the prognostic update here only, dispatched over the type of implicit
-    # without an implicit solver we compute both tendency average and update
-    # here in one kernel, notation following largely Hotta et al. 2016
+    # notation following largely Hotta et al. 2016
     F = get_step(tendency, 1)   # tendency of current time step (or weighted + implicitly corrected tendency)
     G = get_step(tendency, 2)   # accumulated weighted tendencies
 

--- a/SpeedyWeather/src/time_stepping/time_integration.jl
+++ b/SpeedyWeather/src/time_stepping/time_integration.jl
@@ -111,12 +111,13 @@ function update_prognostic!(
     )
     (; prognostic, tendencies) = vars
     (; clock) = prognostic
+    scale = prognostic.scale[]
 
     # atmospheric variables
     for varname in tendency_names(vars)
         var = getfield(prognostic, varname)
         tendency = getfield(tendencies, varname)
-        update_prognostic!(var, tendency, clock, time_stepping, model.implicit, model)
+        update_prognostic!(var, tendency, clock, scale, time_stepping, model.implicit, model)
     end
 
     # and time stepping for tracers if active
@@ -124,22 +125,22 @@ function update_prognostic!(
         if tracer.active
             var = prognostic.tracers[name]
             tendency = tendencies.tracers[name]
-            update_prognostic!(var, tendency, clock, time_stepping, model.implicit, model)
+            update_prognostic!(var, tendency, clock, scale, time_stepping, model.implicit, model)
         end
     end
 
-    # ocean variables
+    # ocean variables, use unscaled time step
     for varname in ocean_tendency_names(vars)
         var = getfield(prognostic.ocean, varname)
         tendency = getfield(tendencies.ocean, varname)
-        update_prognostic!(var, tendency, clock, time_stepping, model.implicit, model)
+        update_prognostic!(var, tendency, clock, one(scale), time_stepping, model.implicit, model)
     end
 
-    # land variables
+    # land variables, use unscaled time step
     for varname in land_tendency_names(vars)
         var = getfield(prognostic.land, varname)
         tendency = getfield(tendencies.land, varname)
-        update_prognostic!(var, tendency, clock, time_stepping, model.implicit, model)
+        update_prognostic!(var, tendency, clock, one(scale), time_stepping, model.implicit, model)
     end
 
     # evolve the random pattern in time

--- a/SpeedyWeather/src/time_stepping/time_integration.jl
+++ b/SpeedyWeather/src/time_stepping/time_integration.jl
@@ -117,7 +117,7 @@ function update_prognostic!(
     for varname in tendency_names(vars)
         var = getfield(prognostic, varname)
         tendency = getfield(tendencies, varname)
-        update_prognostic!(var, tendency, clock, scale, time_stepping, model.implicit, model)
+        update_prognostic!(var, tendency, clock, time_stepping, model.implicit, model, scale)
     end
 
     # and time stepping for tracers if active
@@ -125,7 +125,7 @@ function update_prognostic!(
         if tracer.active
             var = prognostic.tracers[name]
             tendency = tendencies.tracers[name]
-            update_prognostic!(var, tendency, clock, scale, time_stepping, model.implicit, model)
+            update_prognostic!(var, tendency, clock, time_stepping, model.implicit, model, scale)
         end
     end
 
@@ -133,14 +133,14 @@ function update_prognostic!(
     for varname in ocean_tendency_names(vars)
         var = getfield(prognostic.ocean, varname)
         tendency = getfield(tendencies.ocean, varname)
-        update_prognostic!(var, tendency, clock, one(scale), time_stepping, model.implicit, model)
+        update_prognostic!(var, tendency, clock, time_stepping, model.implicit, model)
     end
 
     # land variables, use unscaled time step
     for varname in land_tendency_names(vars)
         var = getfield(prognostic.land, varname)
         tendency = getfield(tendencies.land, varname)
-        update_prognostic!(var, tendency, clock, one(scale), time_stepping, model.implicit, model)
+        update_prognostic!(var, tendency, clock, time_stepping, model.implicit, model)
     end
 
     # evolve the random pattern in time

--- a/SpeedyWeather/test/differentiability/barotropic.jl
+++ b/SpeedyWeather/test/differentiability/barotropic.jl
@@ -229,7 +229,7 @@ end
     spectral_grid = SpectralGrid(trunc = 9, nlayers = 1)          # define resolution
     model = BarotropicModel(; spectral_grid)   # construct model
     simulation = initialize_with_spinup!(model)
-    (; Δt, Δt_sec) = simulation.model.time_stepping
+    (; Δt) = simulation.model.time_stepping
     dt = Δt
     ps = parameters(model)
     pvec = vec(ps)

--- a/SpeedyWeather/test/dynamics/horizontal_diffusion.jl
+++ b/SpeedyWeather/test/dynamics/horizontal_diffusion.jl
@@ -6,6 +6,7 @@
             horizontal_diffusion = HD(spectral_grid)
             model = PrimitiveWetModel(spectral_grid; horizontal_diffusion)
             simulation = initialize!(model)
+            initialize!(simulation)
 
             (; variables) = simulation
             (; expl, impl) = model.horizontal_diffusion
@@ -34,10 +35,8 @@
             @test any(vor .== vor2)    # check that at least some coefficients are identical
 
             # damping should not increase real or imaginary part of variable
-            for lmk in eachindex(vor, vor2)
-                @test abs(real(vor2[lmk])) <= abs(real(vor[lmk]))
-                @test abs(imag(vor2[lmk])) <= abs(imag(vor[lmk]))
-            end
+            @test all(abs.(real.(vor2)) .<= abs.(real.(vor)))
+            @test all(abs.(imag.(vor2)) .<= abs.(imag.(vor)))
         end
     end
 end

--- a/SpeedyWeather/test/dynamics/time_stepping.jl
+++ b/SpeedyWeather/test/dynamics/time_stepping.jl
@@ -8,7 +8,6 @@ F(x, ω) = im * ω * x
     Δt = 2π / 192       # time step
     n_rotations = 1     # times around the circle
     n_time_steps = round(Int, 2π * n_rotations / (ω * Δt))
-    scale = 1
 
     # loop over different precisions
     @testset for NF in (Float32, Float64)
@@ -36,7 +35,7 @@ F(x, ω) = im * ω * x
             # leapfrog forward
             for i in 1:n_time_steps-1
                 dX.data .= F.(X[:, 2], NF(ω))
-                SpeedyWeather.update_prognostic!(X, dX, clock, scale, L, nothing, model)
+                SpeedyWeather.update_prognostic!(X, dX, clock, L, nothing, model)
             end
 
             # absolute error to exact result 1+0i
@@ -48,7 +47,7 @@ F(x, ω) = im * ω * x
             # long term stability
             for i in 1:10*n_time_steps
                 dX.data .= F.(X[:, 2], NF(ω))
-                SpeedyWeather.update_prognostic!(X, dX, clock, scale, L, nothing, model)
+                SpeedyWeather.update_prognostic!(X, dX, clock, L, nothing, model)
             end
 
             @test all(abs.(X) .<= 1)         # still stable?
@@ -69,7 +68,6 @@ end
 
     Δt = 1
     time_stepping.Δt = Δt
-    scale = 1
 
     # initial conditions in step 1, 0 in step 2
     X  = simulation.variables.prognostic.vorticity
@@ -92,7 +90,7 @@ end
     dX = rand(Complex{NF}, spectral_grid.spectrum, 1, 1)
     dX .= real.(dX)             # make them real only to better tell them apart
     dX1 = get_step(dX, 1)
-    SpeedyWeather.update_prognostic!(X, dX, clock, scale, time_stepping, model.implicit, model)
+    SpeedyWeather.update_prognostic!(X, dX, clock, time_stepping, model.implicit, model)
     SpeedyWeather.time_step!(clock, time_stepping)
 
     # this Euler step does not count as time step but as step
@@ -108,7 +106,7 @@ end
     # new time step, new random tendencies
     dX .= rand(Complex{NF}, spectral_grid.spectrum, 1, 1)
     dX .= im*imag.(dX)          # make them imaginary only to better tell them apart
-    SpeedyWeather.update_prognostic!(X, dX, clock, scale, time_stepping, model.implicit, model)
+    SpeedyWeather.update_prognostic!(X, dX, clock, time_stepping, model.implicit, model)
     SpeedyWeather.time_step!(clock, time_stepping)
 
     # this Leapfrog step does count!
@@ -123,7 +121,7 @@ end
 
     # new time step, new random tendencies
     dX .= rand(Complex{NF}, spectral_grid.spectrum, 1, 1)
-    SpeedyWeather.update_prognostic!(X, dX, clock, scale, time_stepping, model.implicit, model)
+    SpeedyWeather.update_prognostic!(X, dX, clock, time_stepping, model.implicit, model)
     SpeedyWeather.time_step!(clock, time_stepping)
 
     # this Leapfrog step does count!
@@ -139,7 +137,7 @@ end
 
     # new time step, new random tendencies
     dX .= rand(Complex{NF}, spectral_grid.spectrum, 1, 1)
-    SpeedyWeather.update_prognostic!(X, dX, clock, scale, time_stepping, model.implicit, model)
+    SpeedyWeather.update_prognostic!(X, dX, clock, time_stepping, model.implicit, model)
     SpeedyWeather.time_step!(clock, time_stepping)
 
     # this Leapfrog step does count!
@@ -180,7 +178,7 @@ end
 
                 for i in 1:n_time_steps
                     dX[:, 1] .= F.(X, NF(ω))        # tendency in the first step (second is multistep averaged tendency)
-                    SpeedyWeather.update_prognostic!(X, dX, clock, scale, L, nothing, model)
+                    SpeedyWeather.update_prognostic!(X, dX, clock, L, nothing, model)
                     SpeedyWeather.time_step!(clock, L)
                 end
 

--- a/SpeedyWeather/test/dynamics/time_stepping.jl
+++ b/SpeedyWeather/test/dynamics/time_stepping.jl
@@ -8,6 +8,7 @@ F(x, ω) = im * ω * x
     Δt = 2π / 192       # time step
     n_rotations = 1     # times around the circle
     n_time_steps = round(Int, 2π * n_rotations / (ω * Δt))
+    scale = 1
 
     # loop over different precisions
     @testset for NF in (Float32, Float64)
@@ -35,7 +36,7 @@ F(x, ω) = im * ω * x
             # leapfrog forward
             for i in 1:n_time_steps-1
                 dX.data .= F.(X[:, 2], NF(ω))
-                SpeedyWeather.update_prognostic!(X, dX, clock, L, nothing, model)
+                SpeedyWeather.update_prognostic!(X, dX, clock, scale, L, nothing, model)
             end
 
             # absolute error to exact result 1+0i
@@ -47,7 +48,7 @@ F(x, ω) = im * ω * x
             # long term stability
             for i in 1:10*n_time_steps
                 dX.data .= F.(X[:, 2], NF(ω))
-                SpeedyWeather.update_prognostic!(X, dX, clock, L, nothing, model)
+                SpeedyWeather.update_prognostic!(X, dX, clock, scale, L, nothing, model)
             end
 
             @test all(abs.(X) .<= 1)         # still stable?
@@ -68,6 +69,7 @@ end
 
     Δt = 1
     time_stepping.Δt = Δt
+    scale = 1
 
     # initial conditions in step 1, 0 in step 2
     X  = simulation.variables.prognostic.vorticity
@@ -90,7 +92,7 @@ end
     dX = rand(Complex{NF}, spectral_grid.spectrum, 1, 1)
     dX .= real.(dX)             # make them real only to better tell them apart
     dX1 = get_step(dX, 1)
-    SpeedyWeather.update_prognostic!(X, dX, clock, time_stepping, model.implicit, model)
+    SpeedyWeather.update_prognostic!(X, dX, clock, scale, time_stepping, model.implicit, model)
     SpeedyWeather.time_step!(clock, time_stepping)
 
     # this Euler step does not count as time step but as step
@@ -106,7 +108,7 @@ end
     # new time step, new random tendencies
     dX .= rand(Complex{NF}, spectral_grid.spectrum, 1, 1)
     dX .= im*imag.(dX)          # make them imaginary only to better tell them apart
-    SpeedyWeather.update_prognostic!(X, dX, clock, time_stepping, model.implicit, model)
+    SpeedyWeather.update_prognostic!(X, dX, clock, scale, time_stepping, model.implicit, model)
     SpeedyWeather.time_step!(clock, time_stepping)
 
     # this Leapfrog step does count!
@@ -121,7 +123,7 @@ end
 
     # new time step, new random tendencies
     dX .= rand(Complex{NF}, spectral_grid.spectrum, 1, 1)
-    SpeedyWeather.update_prognostic!(X, dX, clock, time_stepping, model.implicit, model)
+    SpeedyWeather.update_prognostic!(X, dX, clock, scale, time_stepping, model.implicit, model)
     SpeedyWeather.time_step!(clock, time_stepping)
 
     # this Leapfrog step does count!
@@ -137,7 +139,7 @@ end
 
     # new time step, new random tendencies
     dX .= rand(Complex{NF}, spectral_grid.spectrum, 1, 1)
-    SpeedyWeather.update_prognostic!(X, dX, clock, time_stepping, model.implicit, model)
+    SpeedyWeather.update_prognostic!(X, dX, clock, scale, time_stepping, model.implicit, model)
     SpeedyWeather.time_step!(clock, time_stepping)
 
     # this Leapfrog step does count!
@@ -155,6 +157,7 @@ end
     Δt = 2π / 192        # time step, choose 120 as both 3 and 4 are divisors
     n_rotations = 1     # times around the circle
     n_time_steps = round(Int, 2π * n_rotations / (ω * Δt))
+    scale = 1
 
     # loop over different precisions
     @testset for NF in (Float32, Float64)
@@ -177,7 +180,7 @@ end
 
                 for i in 1:n_time_steps
                     dX[:, 1] .= F.(X, NF(ω))        # tendency in the first step (second is multistep averaged tendency)
-                    SpeedyWeather.update_prognostic!(X, dX, clock, L, nothing, model)
+                    SpeedyWeather.update_prognostic!(X, dX, clock, scale, L, nothing, model)
                     SpeedyWeather.time_step!(clock, L)
                 end
 

--- a/SpeedyWeather/test/dynamics/time_stepping.jl
+++ b/SpeedyWeather/test/dynamics/time_stepping.jl
@@ -215,9 +215,8 @@ end
                 spectral_grid = SpectralGrid(; trunc)
                 time_stepping = TS(spectral_grid)
                 set!(time_stepping, Δt=Δt)
-                @test time_stepping.Δt_sec == Minute(Δt).value * 60
-                @test time_stepping.Δt ≈ time_stepping.Δt_sec / SpeedyWeather.DEFAULT_RADIUS
-                @test time_stepping.Δt_millisec == Millisecond(Second(time_stepping.Δt_sec))
+                @test time_stepping.Δt == Second(Δt).value
+                @test time_stepping.Δt_millisec == Millisecond(Second(time_stepping.Δt))
                 @test time_stepping.Δt_at_T31 == Second(Second(Δt).value / ((trunc + 1) / (SpeedyWeather.DEFAULT_TRUNC + 1)))
             end
         end

--- a/docs/src/barotropic.md
+++ b/docs/src/barotropic.md
@@ -188,14 +188,13 @@ with
 - ``\tilde{\nu} = \nu^* R``, the scaled diffusion coefficient ``\nu^*``, which itself is normalized to a damping time scale, see [Normalization of diffusion](@ref).
 
 So scaling with the radius squared means we can use dimensionless operators, however, this comes at the
-cost of needing to deal with both a time step in seconds as well as a scaled time step in seconds per
-meter, which can be confusing. Furthermore, some constants like Coriolis or the diffusion coefficient
-need to be scaled too during initialization, which may be confusing too because values are not
-what users expect them to be. SpeedyWeather.jl follows the logic that the scaling to the prognostic
-variables is only applied just before the time integration and variables are unscaled for output
-and after the time integration finished. That way, the scaling is hidden as much as possible from
-the user. In hopefully many other cases it is clearly denoted that a variable or constant is
-*scaled*.
+cost of some constants like Coriolis or the diffusion coefficient needing to be scaled too during
+initialization, which may be confusing because values are not what users expect them to be.
+SpeedyWeather.jl follows the logic that the scaling to the prognostic variables is only applied just
+before the time integration and variables are unscaled for output and after the time integration
+finished. The scaled time step (seconds per meter) is applied on the fly within the time integration
+and is not exposed to the user. In hopefully many other cases it is clearly denoted that a variable
+or constant is *scaled*.
 
 ## References
 

--- a/docs/src/barotropic.md
+++ b/docs/src/barotropic.md
@@ -188,8 +188,9 @@ with
 - ``\tilde{\nu} = \nu^* R``, the scaled diffusion coefficient ``\nu^*``, which itself is normalized to a damping time scale, see [Normalization of diffusion](@ref).
 
 So scaling with the radius squared means we can use dimensionless operators, however, this comes at the
-cost of some constants like Coriolis or the diffusion coefficient needing to be scaled too during
+cost of some constants like the diffusion coefficient needing to be scaled too during
 initialization, which may be confusing because values are not what users expect them to be.
+In general we try to scale as much as possible on the fly to hide it from the user.
 SpeedyWeather.jl follows the logic that the scaling to the prognostic variables is only applied just
 before the time integration and variables are unscaled for output and after the time integration
 finished. The scaled time step (seconds per meter) is applied on the fly within the time integration

--- a/docs/src/differentiability.md
+++ b/docs/src/differentiability.md
@@ -133,7 +133,7 @@ We can use the resulting parameter vector to calculate sensitivities over a sing
 ```julia
 initialize!(simulation)
 run!(simulation, period=Day(10))
-(; Δt, Δt_sec) = simulation.model.time_stepping
+(; Δt) = simulation.model.time_stepping
 ps = parameters(model)
 pvec = vec(ps)
 dp = zero(pvec)

--- a/docs/src/examples_2D.md
+++ b/docs/src/examples_2D.md
@@ -347,7 +347,7 @@ model.atmosphere.layer_thickness
 so those waves are with an amplitude of 2000m quite strong.
 But the semi-implicit time integration can handle that even with fairly large time steps of
 ```@example gravity_wave_setup
-model.time_stepping.Δt_sec
+model.time_stepping.Δt
 ```
 seconds. Note that the gravity wave speed here is ``\sqrt{gH}`` so almost 300m/s,
 given the speed of gravity waves we don't have to integrate for long.

--- a/docs/src/forcing_drag.md
+++ b/docs/src/forcing_drag.md
@@ -138,9 +138,8 @@ actually do
 function SpeedyWeather.initialize!( forcing::StochasticStirring,
                                     model::AbstractModel)
 
-    # precompute forcing strength, scale with radius^2 as is the vorticity equation
-    (; radius) = model.planet
-    A = radius^2 * forcing.strength
+    # precompute forcing strength, scale with radius as is the vorticity equation
+    A = forcing.strength * model.planet.radius
 
     # precompute noise and auto-regressive factor, packed in RefValue for mutability
     dt = model.time_stepping.Δt                 # in seconds
@@ -181,8 +180,11 @@ initialize or generally alter several model components in one, but that is not a
 and can easily lead to unexpected behaviour because of multiple dispatch.
 
 As a last note on `initialize!`, you can see that we scale the amplitude/strength `A`
-with the radius squared, this is because the [Barotropic vorticity equation](@ref barotropic_vorticity_model)
-are scaled that way, so we have to scale `S` too.
+with the radius, this is because the [Barotropic vorticity equation](@ref barotropic_vorticity_model)
+is scaled that way, so we have to scale `S` too. The scaling applied to the dynamical core
+is mostly hidden from the user but adding a forcing not proportional to vorticity is
+one of the few exceptions where we do need to apply the scaling manually.
+For more details see [Forcing scaling](@ref).
 
 ## Custom forcing: forcing! function
 
@@ -420,3 +422,54 @@ so this should have the normal units of m/s instead.
 Each of these tendencies will have an additional [Step dimension](@ref) and so
 you will need to view the right step with `get_tendency_step(tend, time_stepping, forcing)`
 which lets the time stepper decide.
+
+## Forcing scaling
+
+In SpeedyWeather all (atmospheric) prognostic equations are scaled with the radius ``R`` of the planet,
+see [Radius scaling](@ref scaling). We also use radius-scaled vorticity and divergence so these
+two equations are effectively scaled by ``R^2``. This scaling is mostly hidden from the user and
+is applied within the dynamical core such that as a user/developer you can mostly ignore this.
+The tendencies of parameterizations + forcing + drag are being scaled automatically within the dynamical core,
+so adding a custom term forcing the temperature you can simply write this to have units of Kelvin per second
+and do not worry about scaling.
+
+!!! info "Manual scaling only required for spectral forcing of vorticity or divergence"
+    Any tendency that's formulated as a parameterization, forcing or drag does not have to be scaled
+    unless you are forcing the vorticity or divergence equation directly (and not via ``u, v``).
+    The correct scaling is automatically applied within the dynamical core.
+    Only when forcing vorticity or divergence directly (and in spectral space) manual scaling may
+    apply, read on for the details.
+
+However, there is a few remaining situations where you do need to account for scaling which are discussed here.
+In brief, this only applies when you force the vorticity or divergence equation directly.
+And also then only when this forcing is not proportional to vorticity or divergence.
+To illustrate this compare two terms,
+
+```math
+\begin{aligned}
+\frac{\partial \zeta}{\partial t} &= F \qquad &(1)\\
+\frac{\partial \zeta}{\partial t} &= a\zeta \qquad &(2)
+\end{aligned}
+```
+
+now scale both equations with ``R^2`` one radius scaling is going into the time step ``t \to t/R = t^\star``,
+the other one into the variable itself ``\zeta \to \zeta R = \zeta^\star``, then we have
+
+```math
+\begin{aligned}
+\frac{\partial \zeta^\star}{\partial t^\star} &= R^2F = RF^\star \qquad &(1)\\
+\frac{\partial \zeta^\star}{\partial t^\star} &= (a\zeta^\star)^\star \qquad &(2)
+\end{aligned}
+```
+
+So the in the (1) case, one ``R`` is automatically applied when scaling the tendency (outside of the definition of that forcing)
+but the 2nd ``R`` is required to be applied within the formulation of the forcing itself.
+In the (2) case, one radius-scaling goes into the variable ``\zeta^\star`` (which is what the dynamical core uses), the 2nd radius-scaling
+is automatically applied when the tendencies enter the dynamical core. So a term of the form (2) can be written without worrying about scaling.
+The reason no radius scaling applies in (2) is that this term is linear/proportional to the vorticity (or divergence).
+Mathematically, this generalizes to
+
+- Forcing vorticity or divergence with a constant/non-linear term ``\propto \zeta^n`` where ``n \neq 1`` then manual scaling with ``R^{1-n}`` has to be applied
+
+Forcing vorticity with a constant (``n=0``) one has to scale that forcing with ``R`` manually (as shown above and for the `StochasticStirring`).
+If forcing with a quadratic term (``n=2``), manual scaling with ``1/R`` has to be applied, and for higher order terms similarly.

--- a/docs/src/forcing_drag.md
+++ b/docs/src/forcing_drag.md
@@ -143,7 +143,7 @@ function SpeedyWeather.initialize!( forcing::StochasticStirring,
     A = radius^2 * forcing.strength
 
     # precompute noise and auto-regressive factor, packed in RefValue for mutability
-    dt = model.time_stepping.Δt_sec
+    dt = model.time_stepping.Δt                 # in seconds
     τ = forcing.decorrelation_time.value        # in seconds
     forcing.a[] = A*sqrt(1 - exp(-2dt/τ))
     forcing.b[] = exp(-dt/τ)

--- a/docs/src/how_to_run_speedy.md
+++ b/docs/src/how_to_run_speedy.md
@@ -119,13 +119,10 @@ depends on a `SpectralGrid` as first argument.
 spectral_grid = SpectralGrid(trunc=63, nlayers=1)
 time_stepping = Leapfrog(spectral_grid, Δt_at_T31=Minute(15))
 ```
-The actual time step at the given resolution (here T63) is then `Δt_sec`, there's
-also `Δt` which is a scaled time step used internally, because SpeedyWeather.jl
-[scales the equations](@ref scaled_swm) with the radius of the Earth,
-but this is largely hidden (except here) from the user. With this new 
-`Leapfrog` time stepper constructed we can create a model by passing
+The actual time step at the given resolution (here T63) is then `Δt`.
+With this new `Leapfrog` time stepper constructed we can create a model by passing
 on the components (they are keyword arguments so either use `; time_stepping`
-for which the naming must match, or `time_stepping=my_time_stepping` with
+for which the naming must match, or `time_stepping = my_time_stepping` with
 any name)
 ```@example howto
 model = ShallowWaterModel(spectral_grid; time_stepping)

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -54,7 +54,7 @@ Example, we run the model at a resolution of T42 and the time step is going to b
 ```@example netcdf
 spectral_grid = SpectralGrid(trunc=42, nlayers=1)
 time_stepping = Leapfrog(spectral_grid)
-time_stepping.Δt_sec
+time_stepping.Δt
 ```
 seconds. Depending on the output frequency (we chose `interval = Hour(1)` above)
 this will be slightly adjusted during model initialization:
@@ -62,7 +62,7 @@ this will be slightly adjusted during model initialization:
 output = NetCDFOutput(spectral_grid, ShallowWater, interval=Hour(1))
 model = ShallowWaterModel(spectral_grid; time_stepping, output)
 simulation = initialize!(model)
-model.time_stepping.Δt_sec
+model.time_stepping.Δt
 ```
 The shorter the output interval the more the model time step needs to be adjusted
 to match the desired interval exactly. This is important so that for daily output at
@@ -70,7 +70,7 @@ noon this does not slowly shift towards night over years of the model integratio
 One can always disable this adjustment with
 ```@example netcdf
 time_stepping = Leapfrog(spectral_grid, adjust_with_output=false)
-time_stepping.Δt_sec
+time_stepping.Δt
 ```
 and a little info will be printed to explain that even though you wanted
 `interval = Hour(1)` you will not actually get this upon initialization:

--- a/docs/src/primitiveequation.md
+++ b/docs/src/primitiveequation.md
@@ -853,7 +853,12 @@ Now loop over
 
 ## Scaled primitive equations
 
-TODO
+The primitive equations in SpeedyWeather are scaled by the radius, and vorticity and divergence variables are also scaled by the radius,
+effectively scaling these equations by the radius squared. However, in most cases this scaling is hidden from the user and developer
+and only when forcing vorticity or divergence directly it has to be applied manually. Otherwise all scaling is done internally,
+see [Forcing scaling](@ref) for more details.
+
+Derivation of the scaled primitive equations will be added here.
 
 ## References
 

--- a/docs/src/shallowwater.md
+++ b/docs/src/shallowwater.md
@@ -271,6 +271,10 @@ does not actually change because ``\xi^2\nabla^2 = \tilde{\xi}^2\tilde{\nabla}^2
 ``1/R^2``, but the Laplace operator with ``R^2``. So overall we just have to use the scaled time step ``\tilde{\Delta t}``
 and normalized eigenvalues for ``\tilde{\nabla}^2``.
 
+When adding (custom) forcing or drag terms, in most cases this scaling does not have to be applied
+manually but is done automatically within the dynamical core. But there are exceptions,
+see [Forcing scaling](@ref) for more details.
+
 
 ## References
 

--- a/docs/src/time_integration.md
+++ b/docs/src/time_integration.md
@@ -147,8 +147,7 @@ This is such that in most cases the user does need to know what time step is sta
 you want a shorter time step the easiest is to choose `Δt_at_T31` (write `\Delta` then hit tab,
 works in the Julia REPL and other interfaces) relative to its default. If you half that time step
 you'll half the time step for all resolutions. The other "time steps" in `time_stepping` are
-explained in the docstring (`?Leapfrog`). Note that internally SpeedyWeather uses a time step
-scaled by the radius, so `time_stepping.Δt` will be in units of second divided by meter.
+explained in the docstring (`?Leapfrog`).
 
 You can also choose the time step manually with
 


### PR DESCRIPTION
Why?

- All atmospheric variables use a scaled time step, ocean and land do not, so the time stepper needs to run some `update_prognostic!` calls with scale some without.
- The scaled time step in `model.time_stepping` is user-facing and can cause confusion, we therefore want to hide the scaled time step ideally

This now
- treats every atmospheric + tracer variable with a scaled time step, ocean, land and sea ice without
- removes `model.time_stepping.Δt_sec` because `.Δt` is in seconds now and not s/m because /radius

# Compatibility summary

- `model.time_stepping.Δt_sec` has been removed, use `.Δt` instead, it's the unscaled time step now in seconds.
- In most cases, custom forcings should not include a scaling with the radius, see docs "Forcing scaling"

@pierluigividale You suggested this PR a while ago, here you go. Possible places where your code might be breaking ☝🏼 

# Summary

Now all parameterizations + forcing + drag are being scaled automatically within the dynamical core, so for most forcing/drag/parameterizations a user/developer doesn't need to worry about it. The one remaining place where scaling has to be done manually is when forcing vorticity/divergence directly (not u, v, or any other variable) and when that forcing is not proportional to these variables respectively, i.e. compare

```math
\begin{aligned}
\frac{\partial \zeta}{\partial t} &= F \qquad &(1)\\
\frac{\partial \zeta}{\partial t} &= a\zeta \qquad &(2)
\end{aligned}
```

now scale both with $R^2$ (all other equations are scaled with $R$ meaning for temperature, humidity, pressure, the following does not apply ...), one radius scaling is going into the time step $t \to t/R = t^\star$, the other one into the variable itself $\zeta \to \zeta R = \zeta^\star$, then we have

```math
\begin{aligned}
\frac{\partial \zeta^\star}{\partial t^\star} &= R^2F = RF^\star \qquad &(1)\\
\frac{\partial \zeta^\star}{\partial t^\star} &= (a\zeta^\star)^\star \qquad &(2)
\end{aligned}
```

So the in the (1) case, one $R$ is the now automatically applied scaling of the tendency but the 2nd one is necessary to do by hand. In the (2) one R-scaling goes into the variable $\zeta^\star$ one is automatically applied now, so a user/developer can just write their function without worrying about scaling, which is the philosophy I would like to have, only exception is

- if you force vorticity or divergence with a constant/non-linear term $\propto \zeta^n$ where $n \neq 1$ then manual scaling with $R^{1-n}$ has to be applied
- this only applies for forcing in spectral space (you can't force those in grid space, see docs @ "Allowed forcings") with a constant ($n=0$, so scale with $R$ manually), or a quadratic ($n=2$, so scale with $1/R$), and higher order terms similarly ... 