### PR TITLE
Rotate/reverse for Field/LowerTriangularArray kernelized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Rotate/reverse Field/LowerTriangularArray kernelized [#1154](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1154)
 - ArrayDimensions in RingGrids and LowerTriangularArrays [#1150](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1150/)
 - Terrarium coupling uses the allocation-free masked copy to optimize performance [#1152](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1152)
 - Improved compatability with Enzyme with Julia 1.12: `get_step` instead of `get_steps` used more commonly and default `maxtypeoffset!` increased [#1143](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1143)

--- a/LowerTriangularArrays/src/rotate_reverse.jl
+++ b/LowerTriangularArrays/src/rotate_reverse.jl
@@ -6,20 +6,28 @@ Rotate the field(s) represented by a LowerTriangularArray zonally by `degree`
 by multiplication of the spherical harmonics by exp(-i*m*2π*degree/360),
 with `m` the order of the spherical harmonic."""
 function rotate!(L::LowerTriangularArray, degree::Real)
-    lmax, mmax = size(L, OneBased, as = Matrix)
+    mmax = size(L, 2, OneBased, as = Matrix)
 
-    for k in eachmatrix(L)
-        lm = 0
-        for m in 1:mmax
-            # complex rotation, exp(-i*m*2π*degree/360) but more accurate
-            o = convert(complex(eltype(L)), cispi(-(m - 1) * degree / 180))
-            for l in m:lmax
-                lm += 1
-                L[lm, k] *= o
-            end
-        end
-    end
+    # complex rotation per order m, exp(-i*m*2π*degree/360) but more accurate;
+    # precomputed in the precision of `degree` before conversion for accuracy
+    NF = complex(eltype(L))
+
+    # allocates a vector here but keeps the cispi out of kernels
+    # which is not supported on some architectures (e.g. Metal)
+    rotation = [convert(NF, cispi(-(m - 1) * degree / 180)) for m in 1:mmax]
+
+    arch = architecture(L)
+    launch!(
+        arch, SpectralWorkOrder, size(L), rotate_kernel!,
+        L.data, on_architecture(arch, rotation), L.spectrum.m_indices,
+    )
     return L
+end
+
+@kernel inbounds = true function rotate_kernel!(data, @Const(rotation), @Const(m_indices))
+    I = @index(Global, NTuple)
+    m = m_indices[I[1]]     # order m of the harmonic at running index lm = I[1]
+    data[I...] *= rotation[m]
 end
 
 # also allow long names longitude, latitude
@@ -35,20 +43,18 @@ represent the coefficients of the spherical harmonics. Reversal
 in latitude direction is obtained by flipping the sign of the
 odd harmonics. Reverses `L` in place."""
 function Base._reverse!(L::LowerTriangularArray, ::Val{:lat})
-    lmax, mmax = size(L, OneBased, as = Matrix)
-
-    for k in eachmatrix(L)      # loop over any additional dimensions
-        lm = 0
-        for m in 1:mmax
-            for l in m:lmax
-                lm += 1
-                if isodd(l + m)   # odd harmonics only
-                    L[lm, k] = -L[lm, k]
-                end
-            end
-        end
-    end
+    (; l_indices, m_indices) = L.spectrum
+    arch = architecture(L)
+    launch!(arch, SpectralWorkOrder, size(L), reverse_lat_kernel!, L.data, l_indices, m_indices)
     return L
+end
+
+@kernel inbounds = true function reverse_lat_kernel!(data, @Const(l_indices), @Const(m_indices))
+    I = @index(Global, NTuple)
+    lm = I[1]
+    if isodd(l_indices[lm] + m_indices[lm])     # odd harmonics only
+        data[I...] = -data[I...]
+    end
 end
 
 """$(TYPEDSIGNATURES)

--- a/LowerTriangularArrays/src/rotate_reverse.jl
+++ b/LowerTriangularArrays/src/rotate_reverse.jl
@@ -2,9 +2,10 @@ import LinearAlgebra: rotate!
 export rotate!
 
 """$(TYPEDSIGNATURES)
-Rotate the field(s) represented by a LowerTriangularArray zonally by `degree`
+Rotate the field(s) represented by a LowerTriangularArray zonally eastward by `degree`
 by multiplication of the spherical harmonics by exp(-i*m*2π*degree/360),
-with `m` the order of the spherical harmonic."""
+with `m` the order of the spherical harmonic. Any `degree` is allowed,
+in contrast to the grid-space `rotate!` which is restricted to multiples of 90˚."""
 function rotate!(L::LowerTriangularArray, degree::Real)
     mmax = size(L, 2, OneBased, as = Matrix)
 
@@ -38,10 +39,10 @@ Base._reverse!(L::LowerTriangularArray, ::Val{:longitude}) = Base._reverse!(L, V
 Base._reverse!(L::LowerTriangularArray, sym::Symbol) = Base._reverse!(L, Val(sym))
 
 """$(TYPEDSIGNATURES)
-Reverse the field represented by `L` in latitude when the element in `L`
-represent the coefficients of the spherical harmonics. Reversal
-in latitude direction is obtained by flipping the sign of the
-odd harmonics. Reverses `L` in place."""
+Reverse the field represented by `L` in latitude (mirror at the equator)
+when the elements in `L` represent the coefficients of the spherical harmonics.
+Reversal in latitude direction is obtained by flipping the sign of the
+harmonics with odd degree + order `l + m`. Reverses `L` in place."""
 function Base._reverse!(L::LowerTriangularArray, ::Val{:lat})
     (; l_indices, m_indices) = L.spectrum
     arch = architecture(L)
@@ -58,9 +59,10 @@ end
 end
 
 """$(TYPEDSIGNATURES)
-Reverse the field represented by `L` in longitude (mirror at 0˚)
-when the element in `L` represent the coefficients of the spherical harmonics.
-Reversal in longitude direction is obtained by the complex harmonics.
+Reverse the field represented by `L` in longitude (mirror at the 0˚ meridian)
+when the elements in `L` represent the coefficients of the spherical harmonics.
+Reversal in longitude direction is obtained by taking the complex conjugate
+of the harmonics, consistent with the grid-space `reverse!(field, dims=:lon)`.
 Reverses `L` in place."""
 function Base._reverse!(L::LowerTriangularArray, ::Val{:lon})
     L .= conj.(L)

--- a/LowerTriangularArrays/test/lower_triangular_matrix.jl
+++ b/LowerTriangularArrays/test/lower_triangular_matrix.jl
@@ -1045,3 +1045,21 @@ end
     L2_trunc = LowerTriangularArrays.truncate(L2, 3)
     @test L2_trunc.dims isa LM
 end
+
+@testset "Rotate/Reverse n-dimensional" begin
+    @testset for trailing_dims in ((2,), (2, 3), (2, 3, 2))
+        L = rand(LowerTriangularArray{ComplexF64}, 10, 10, trailing_dims...)
+
+        rotated = rotate!(deepcopy(L), 30)
+        reversed_lat = reverse(L, dims = :lat)
+        reversed_lon = reverse(L, dims = :lon)
+
+        # operating on all matrices at once == operating on every matrix independently
+        for c in CartesianIndices(trailing_dims)
+            layer = L[:, c]
+            @test rotate!(deepcopy(layer), 30) == rotated[:, c]
+            @test reverse(layer, dims = :lat) == reversed_lat[:, c]
+            @test reverse(layer, dims = :lon) == reversed_lon[:, c]
+        end
+    end
+end

--- a/RingGrids/src/grid.jl
+++ b/RingGrids/src/grid.jl
@@ -275,6 +275,21 @@ function eachring_on_architecture(arch, grid::AbstractGrid)
     return on_architecture(arch, first.(rings)), on_architecture(arch, length.(rings))
 end
 
+"""$(TYPEDSIGNATURES) True if the first longitude point on every ring of the grid is offset
+half a longitudinal grid spacing east of the 0˚ meridian, false if the first point lies on
+0˚ exactly. Defined per grid type; grids where only some rings have an offset (`HEALPixGrid`)
+only define the per-ring `hasoffset(Grid, nlat_half, j)`."""
+hasoffset(grid::AbstractGrid) = hasoffset(typeof(grid))
+
+"""$(TYPEDSIGNATURES) Like `hasoffset(grid)` but for ring `j`, for grids like `HEALPixGrid`
+where only some rings have a longitudinal offset."""
+hasoffset(Grid::Type{<:AbstractGrid}, nlat_half::Integer, j::Integer) = hasoffset(Grid)
+
+"""$(TYPEDSIGNATURES) The longitudinal offset of `grid` as passed to kernels: `hasoffset(grid)`
+as a scalar Bool for grids where it is identical on every ring, but a Bool vector (one per
+ring, on architecture `arch`) for grids like `HEALPixGrid` where it is ring-dependent."""
+offset_maybe_vector(arch, grid::AbstractGrid) = hasoffset(grid)
+
 # for architectures / adapt
 Architectures.ismatching(grid::AbstractGrid, array_type::Type{<:AbstractArray}) = ismatching(grid.architecture, array_type)
 Architectures.ismatching(grid::AbstractGrid, array::AbstractArray) = ismatching(grid.architecture, typeof(array))

--- a/RingGrids/src/grid.jl
+++ b/RingGrids/src/grid.jl
@@ -268,6 +268,13 @@ end
 whichring(grid::AbstractGrid) = grid.whichring
 whichring(Grid::Type{<:AbstractGrid}, nlat_half::Integer) = whichring(Grid, nlat_half, eachring(Grid, nlat_half))
 
+"""$(TYPEDSIGNATURES) First index and length of every ring in `grid` as two vectors
+on architecture `arch`, for use inside kernels where the CPU-only `grid.rings` is unavailable."""
+function eachring_on_architecture(arch, grid::AbstractGrid)
+    rings = eachring(grid)
+    return on_architecture(arch, first.(rings)), on_architecture(arch, length.(rings))
+end
+
 # for architectures / adapt
 Architectures.ismatching(grid::AbstractGrid, array_type::Type{<:AbstractArray}) = ismatching(grid.architecture, array_type)
 Architectures.ismatching(grid::AbstractGrid, array::AbstractArray) = ismatching(grid.architecture, typeof(array))

--- a/RingGrids/src/grids/full_clenshaw.jl
+++ b/RingGrids/src/grids/full_clenshaw.jl
@@ -47,6 +47,7 @@ get_nlon(::Type{<:FullClenshawGrid}, nlat_half::Integer) = 4nlat_half
 ## COORDINATES
 get_latd(::Type{<:FullClenshawGrid}, nlat_half::Integer) = [90 - 90j / nlat_half for j in 1:(2nlat_half - 1)]
 get_lond(::Type{<:FullClenshawGrid}, nlat_half::Integer) = get_lond(FullGaussianGrid, nlat_half)
+hasoffset(::Type{<:FullClenshawGrid}) = false   # first longitude point on 0˚
 
 # QUADRATURE
 get_quadrature_weights(::Type{<:FullClenshawGrid}, nlat_half::Integer) = clenshaw_curtis_weights(nlat_half)

--- a/RingGrids/src/grids/full_gaussian.jl
+++ b/RingGrids/src/grids/full_gaussian.jl
@@ -55,5 +55,7 @@ function get_lond(::Type{<:FullGaussianGrid}, nlat_half::Integer)
     return collect(range(0, 360 - 180 / nlon, step = 360 / nlon))
 end
 
+hasoffset(::Type{<:FullGaussianGrid}) = false   # first longitude point on 0˚
+
 # QUADRATURE
 get_quadrature_weights(::Type{<:FullGaussianGrid}, nlat_half::Integer) = gaussian_weights(nlat_half)

--- a/RingGrids/src/grids/full_healpix.jl
+++ b/RingGrids/src/grids/full_healpix.jl
@@ -37,6 +37,7 @@ get_nlon(::Type{<:FullHEALPixGrid}, nlat_half::Integer) = 4nlat_half
 ## COORDINATES
 get_latd(::Type{<:FullHEALPixGrid}, nlat_half::Integer) = get_latd(HEALPixGrid, nlat_half)
 get_lond(::Type{<:FullHEALPixGrid}, nlat_half::Integer) = get_lond(FullGaussianGrid, nlat_half)
+hasoffset(::Type{<:FullHEALPixGrid}) = false    # first longitude point on 0˚
 
 # QUADRATURE (use weights from reduced grids though!)
 get_quadrature_weights(::Type{<:FullHEALPixGrid}, nlat_half::Integer) =

--- a/RingGrids/src/grids/full_octahealpix.jl
+++ b/RingGrids/src/grids/full_octahealpix.jl
@@ -37,6 +37,7 @@ get_nlon(::Type{<:FullOctaHEALPixGrid}, nlat_half::Integer) = 4nlat_half
 ## COORDINATES
 get_latd(::Type{<:FullOctaHEALPixGrid}, nlat_half::Integer) = get_latd(OctaHEALPixGrid, nlat_half)
 get_lond(::Type{<:FullOctaHEALPixGrid}, nlat_half::Integer) = get_lond(FullGaussianGrid, nlat_half)
+hasoffset(::Type{<:FullOctaHEALPixGrid}) = false    # first longitude point on 0˚
 
 # QUADRATURE (use weights from reduced grids though!)
 get_quadrature_weights(::Type{<:FullOctaHEALPixGrid}, nlat_half::Integer) =

--- a/RingGrids/src/grids/healpix.jl
+++ b/RingGrids/src/grids/healpix.jl
@@ -103,6 +103,27 @@ function get_lond_per_ring(Grid::Type{<:HEALPixGrid}, nlat_half::Integer, j::Int
     return lond
 end
 
+# rings with s=1 are offset by dlon/2 east of 0˚, rings with s=2 start on 0˚,
+# so hasoffset is only defined per ring for HEALPixGrid, not for the whole grid
+function hasoffset(::Type{<:HEALPixGrid}, nlat_half::Integer, j::Integer)
+    nside = nside_healpix(nlat_half)
+    s = (j < nside) || (j >= 3nside) ? 1 : ((j - nside) % 2 + 1)
+    return s == 1
+end
+
+hasoffset(::Type{<:HEALPixGrid}) = throw(
+    ArgumentError(
+        "HEALPixGrid has rings with and without longitudinal offset, " *
+            "use hasoffset(Grid, nlat_half, j) per ring instead."
+    )
+)
+
+# ring-dependent offset, so kernels need it as a vector with one Bool per ring
+function offset_maybe_vector(arch, grid::HEALPixGrid)
+    (; nlat_half) = grid
+    return on_architecture(arch, [hasoffset(HEALPixGrid, nlat_half, j) for j in 1:get_nlat(grid)])
+end
+
 ## INDEXING
 function each_index_in_ring(
         ::Type{<:HEALPixGrid},

--- a/RingGrids/src/grids/octahealpix.jl
+++ b/RingGrids/src/grids/octahealpix.jl
@@ -80,6 +80,8 @@ function get_lond_per_ring(Grid::Type{<:OctaHEALPixGrid}, nlat_half::Integer, j:
     return collect((180 / nlon):(360 / nlon):360)
 end
 
+hasoffset(::Type{<:OctaHEALPixGrid}) = true     # first longitude point dlon/2 east of 0˚
+
 ## INDEXING
 function each_index_in_ring(
         ::Type{<:OctaHEALPixGrid},     # function for OctaHEALPix grids

--- a/RingGrids/src/grids/octahedral_clenshaw.jl
+++ b/RingGrids/src/grids/octahedral_clenshaw.jl
@@ -85,6 +85,8 @@ function get_lond_per_ring(Grid::Type{<:OctahedralClenshawGrid}, nlat_half::Inte
     return collect(0:(360 / nlon):(360 - 180 / nlon))
 end
 
+hasoffset(::Type{<:OctahedralClenshawGrid}) = false     # first longitude point on 0˚
+
 ## QUADRATURE
 get_quadrature_weights(::Type{<:OctahedralClenshawGrid}, nlat_half::Integer) =
     clenshaw_curtis_weights(nlat_half)

--- a/RingGrids/src/grids/octahedral_gaussian.jl
+++ b/RingGrids/src/grids/octahedral_gaussian.jl
@@ -79,6 +79,8 @@ function get_lond_per_ring(Grid::Type{<:OctahedralGaussianGrid}, nlat_half::Inte
     return collect(0:(360 / nlon):(360 - 180 / nlon))
 end
 
+hasoffset(::Type{<:OctahedralGaussianGrid}) = false     # first longitude point on 0˚
+
 ## QUADRATURE
 get_quadrature_weights(::Type{<:OctahedralGaussianGrid}, nlat_half::Integer) = gaussian_weights(nlat_half)
 

--- a/RingGrids/src/grids/octaminimal_gaussian.jl
+++ b/RingGrids/src/grids/octaminimal_gaussian.jl
@@ -67,6 +67,8 @@ function get_lond_per_ring(Grid::Type{<:OctaminimalGaussianGrid}, nlat_half::Int
     return collect((180 / nlon):(360 / nlon):360)       # use HEALPix definition for longitudes
 end
 
+hasoffset(::Type{<:OctaminimalGaussianGrid}) = true     # first longitude point dlon/2 east of 0˚
+
 ## QUADRATURE
 get_quadrature_weights(::Type{<:OctaminimalGaussianGrid}, nlat_half::Integer) = gaussian_weights(nlat_half)
 

--- a/RingGrids/src/reordering.jl
+++ b/RingGrids/src/reordering.jl
@@ -18,14 +18,14 @@ function reorder!(
     @assert ispow2(get_nlat_half(field.grid)) "Reordering only supported for nlat_half power of 2, got $(get_nlat_half(field.grid))."
 
     arch = architecture(field)
-    # Ensure worksize is always 2D by adding layer dimension dim=1
-    worksize = ndims(field) == 1 ? (size(field, 1), 1) : size(field)
-    launch!(arch, RingGridWorkOrder, worksize, reorder_kernel!, out, field, order, field.grid)
+    launch!(arch, RingGridWorkOrder, size(field), reorder_kernel!, out, field, order, field.grid)
     return out
 end
 
 @kernel inbounds = true function reorder_kernel!(out, field, order, grid)
-    ij, k = @index(Global, NTuple)
+    I = @index(Global, Cartesian)
+    ij = I[1]                                   # grid point index
+    k = CartesianIndex(Base.tail(Tuple(I)))     # all non-horizontal dimensions
     # TODO the recomputes the reordering for every layer k, maybe distribute only over ij?
     out_indices = reorder(order, ij, grid)
     out[out_indices, k] = field[ij, k]

--- a/RingGrids/src/reverse.jl
+++ b/RingGrids/src/reverse.jl
@@ -1,39 +1,58 @@
+"""$(TYPEDSIGNATURES)
+Reverse `field` in-place along dimension `sym`, called via `reverse!(field, dims=:lat)`.
+`:lat` (or `:latitude`) mirrors the field about the equator,
+`:lon` (or `:longitude`) reverses the direction of every ring."""
 Base._reverse!(field::AbstractField, sym::Symbol) = Base._reverse!(field, Val(sym))
 
+"""$(TYPEDSIGNATURES)
+Mirror `field` about the equator in-place by swapping every northern ring
+with its southern counterpart, as called via `reverse!(field, dims=:lat)`."""
 function Base._reverse!(field::AbstractField, ::Val{:lat})
+    arch = architecture(field)
+    ring_first, ring_length = eachring_on_architecture(arch, field.grid)
+    nrings = get_nlat(field)
 
-    rings = eachring(field)
-    nrings = length(rings)
-    rings_north = view(rings, 1:(nrings ÷ 2))
-
-    @inbounds for k in eachlayer(field)
-        for (j_north, ring) in enumerate(rings_north)
-            j_south = nrings - j_north + 1
-            for (i, ij_north) in enumerate(ring)
-                ij_south = rings[j_south][i]
-
-                # read out northern and southern values
-                north = field[ij_north, k]
-                south = field[ij_south, k]
-
-                # and swap them
-                field[ij_north, k] = south
-                field[ij_south, k] = north
-            end
-        end
-    end
-
+    # one thread per northern ring j (and layer k), swapping with its mirrored southern ring;
+    # for odd nrings the equator ring maps onto itself and is skipped
+    worksize = (nrings ÷ 2, size(field)[2:end]...)
+    launch!(arch, ArrayWorkOrder, worksize, reverse_lat_kernel!, field, nrings, ring_first, ring_length)
     return field
 end
 
-function Base._reverse!(field::AbstractField, ::Val{:lon})
-    for k in eachlayer(field)
-        for ring in eachring(field)
-            field_ring = view(field, ring, k)
-            reverse!(field_ring)
-        end
+@kernel inbounds = true function reverse_lat_kernel!(field, nrings, ring_first, ring_length)
+    I = @index(Global, Cartesian)
+    j = I[1]                                    # northern ring index
+    k = CartesianIndex(Base.tail(Tuple(I)))     # all non-horizontal dimensions
+    j_south = nrings - j + 1                    # mirrored southern ring, same length by symmetry
+    ij_north = ring_first[j]
+    ij_south = ring_first[j_south]
+
+    for i in 1:ring_length[j]
+        field[ij_north, k], field[ij_south, k] = field[ij_south, k], field[ij_north, k]
+        ij_north += 1
+        ij_south += 1
     end
+end
+
+"""$(TYPEDSIGNATURES)
+Reverse the direction of every ring of `field` in-place (west-east mirror),
+as called via `reverse!(field, dims=:lon)`."""
+function Base._reverse!(field::AbstractField, ::Val{:lon})
+    arch = architecture(field)
+    ring_first, ring_length = eachring_on_architecture(arch, field.grid)
+
+    # one thread per ring j (and layer k) as the in-place reversal is sequential within a ring
+    worksize = (get_nlat(field), size(field)[2:end]...)
+    launch!(arch, ArrayWorkOrder, worksize, reverse_lon_kernel!, field, ring_first, ring_length)
     return field
+end
+
+@kernel inbounds = true function reverse_lon_kernel!(field, ring_first, ring_length)
+    I = @index(Global, Cartesian)
+    j = I[1]                                    # ring index
+    k = CartesianIndex(Base.tail(Tuple(I)))     # all non-horizontal dimensions
+    i0 = ring_first[j]
+    reverse_ring!(field, k, i0, i0 + ring_length[j] - 1)
 end
 
 # also allow long names longitude, latitude

--- a/RingGrids/src/reverse.jl
+++ b/RingGrids/src/reverse.jl
@@ -35,24 +35,43 @@ end
 end
 
 """$(TYPEDSIGNATURES)
-Reverse the direction of every ring of `field` in-place (west-east mirror),
-as called via `reverse!(field, dims=:lon)`."""
+Reverse `field` in longitude in-place (mirror at the 0˚ meridian), as called via
+`reverse!(field, dims=:lon)`. On rings with a longitudinal offset (first point dlon/2
+east of 0˚, see `hasoffset`) all points within the ring are reversed; on rings whose
+first point lies on 0˚ that point stays and only the remaining points are reversed.
+Either way the ring is mirrored exactly at 0˚, consistent with the spectral
+`reverse!(::LowerTriangularArray, dims=:lon)`."""
 function Base._reverse!(field::AbstractField, ::Val{:lon})
     arch = architecture(field)
     ring_first, ring_length = eachring_on_architecture(arch, field.grid)
 
+    # true/false if the dlon/2 offset from 0˚ is identical on every ring,
+    # otherwise a Bool vector with one offset per ring (HEALPixGrid)
+    offset = offset_maybe_vector(arch, field.grid)
+
     # one thread per ring j (and layer k) as the in-place reversal is sequential within a ring
     worksize = (get_nlat(field), size(field)[2:end]...)
-    launch!(arch, ArrayWorkOrder, worksize, reverse_lon_kernel!, field, ring_first, ring_length)
+    launch!(arch, ArrayWorkOrder, worksize, reverse_lon_kernel!, field, ring_first, ring_length, offset)
     return field
 end
 
-@kernel inbounds = true function reverse_lon_kernel!(field, ring_first, ring_length)
+# offset rings mirror at 0˚ by reversing all points; rings starting at 0˚ keep their
+# first point (it lies on the mirror axis) and reverse the others, hence + (1 - offset)
+@kernel inbounds = true function reverse_lon_kernel!(field, ring_first, ring_length, offset::Bool)
     I = @index(Global, Cartesian)
     j = I[1]                                    # ring index
     k = CartesianIndex(Base.tail(Tuple(I)))     # all non-horizontal dimensions
-    i0 = ring_first[j]
-    reverse_ring!(field, k, i0, i0 + ring_length[j] - 1)
+    i0 = ring_first[j] + (1 - offset)
+    reverse_ring!(field, k, i0, ring_first[j] + ring_length[j] - 1)
+end
+
+# as above but for grids where the offset is ring-dependent (HEALPixGrid)
+@kernel inbounds = true function reverse_lon_kernel!(field, ring_first, ring_length, offset::AbstractVector)
+    I = @index(Global, Cartesian)
+    j = I[1]                                    # ring index
+    k = CartesianIndex(Base.tail(Tuple(I)))     # all non-horizontal dimensions
+    i0 = ring_first[j] + (1 - offset[j])
+    reverse_ring!(field, k, i0, ring_first[j] + ring_length[j] - 1)
 end
 
 # also allow long names longitude, latitude

--- a/RingGrids/src/rotate.jl
+++ b/RingGrids/src/rotate.jl
@@ -10,10 +10,18 @@ function LongitudeRotation(degree::Integer)
     throw(ArgumentError("Rotation degree must be multiples of 0, 90, 180, or 270; $degree given."))
 end
 
-import LinearAlgebra: rotate!, circshift!
+import LinearAlgebra: rotate!
 export rotate, rotate!
 
+"""$(TYPEDSIGNATURES)
+Rotate `field` eastward in longitude by `degree`, a multiple of 90˚.
+Returns a rotated copy, see `rotate!` for the in-place version."""
 rotate(field::AbstractField, args...) = rotate!(deepcopy(field), args...)
+
+"""$(TYPEDSIGNATURES)
+Rotate `field` eastward in longitude by `degree` in-place, a multiple of 90˚
+(negative degrees rotate westward). Every ring is circularly shifted by the
+corresponding number of quarter rings."""
 rotate!(field::AbstractField, degree::Integer) = rotate!(field, LongitudeRotation(degree))
 rotate!(field::AbstractField, ::LongitudeRotation{0}) = field
 rotate!(field::AbstractField, ::LongitudeRotation{90}) = _rotate!(field, 1)
@@ -22,14 +30,37 @@ rotate!(field::AbstractField, ::LongitudeRotation{270}) = _rotate!(field, 3)
 
 function _rotate!(field::AbstractField, quarter::Integer)
     @assert quarter in (0, 1, 2, 3) "Can only shift by 0, 1, 2, or 3 quarters of a ring"
+    quarter == 0 && return field
 
-    for k in eachlayer(field)
-        for ring in eachring(field)
-            v = view(field, ring, k)
-            shift = quarter * (length(ring) ÷ 4)
-            circshift!(v, shift)
-        end
-    end
+    arch = architecture(field)
+    ring_first, ring_length = eachring_on_architecture(arch, field.grid)
 
+    # one thread per ring j (and layer k) as a circular shift is sequential within a ring
+    worksize = (get_nlat(field), size(field)[2:end]...)
+    launch!(arch, ArrayWorkOrder, worksize, rotate_kernel!, field, quarter, ring_first, ring_length)
     return field
+end
+
+# in-place reverse of field[a:b, k], used for the in-place circular shift below
+@inline function reverse_ring!(field, k, a::Integer, b::Integer)
+    @inbounds while a < b
+        field[a, k], field[b, k] = field[b, k], field[a, k]
+        a += 1
+        b -= 1
+    end
+end
+
+@kernel inbounds = true function rotate_kernel!(field, quarter, ring_first, ring_length)
+    I = @index(Global, Cartesian)
+    j = I[1]                                    # ring index
+    k = CartesianIndex(Base.tail(Tuple(I)))     # all non-horizontal dimensions
+    i0 = ring_first[j]                          # index of first grid point in ring j
+    n = ring_length[j]
+    shift = quarter * (n ÷ 4)
+
+    if shift != 0                       # circshift! by `shift` via triple reversal, in-place
+        reverse_ring!(field, k, i0, i0 + n - shift - 1)
+        reverse_ring!(field, k, i0 + n - shift, i0 + n - 1)
+        reverse_ring!(field, k, i0, i0 + n - 1)
+    end
 end

--- a/RingGrids/src/scaling.jl
+++ b/RingGrids/src/scaling.jl
@@ -24,14 +24,14 @@ function _scale_lat!(field::AbstractField, v::AbstractVector)
     @boundscheck get_nlat(field) == length(v) || throw(DimensionMismatch(field, v))
 
     arch = architecture(field)
-    # Ensure worksize is always 2D by adding layer dimension dim=1
-    worksize = ndims(field) == 1 ? (size(field, 1), 1) : size(field)
-    launch!(arch, RingGridWorkOrder, worksize, scale_lat_kernel!, field, v, whichring(field.grid))
+    launch!(arch, RingGridWorkOrder, size(field), scale_lat_kernel!, field, v, whichring(field.grid))
     return field
 end
 
 @kernel inbounds = true function scale_lat_kernel!(field, v, whichring)
-    ij, k = @index(Global, NTuple)
+    I = @index(Global, Cartesian)
+    ij = I[1]                                   # grid point index
+    k = CartesianIndex(Base.tail(Tuple(I)))     # all non-horizontal dimensions
     j = whichring[ij]   # get ring index for grid point ij
     field[ij, k] *= v[j]
 end

--- a/RingGrids/test/reordering.jl
+++ b/RingGrids/test/reordering.jl
@@ -35,3 +35,19 @@ end
         end
     end
 end
+
+@testset "Reordering n-dimensional fields" begin
+    grid = OctaHEALPixGrid(4)
+    @testset for trailing_dims in ((2,), (2, 3), (2, 3, 2))
+        field = rand(Float32, grid, trailing_dims...)
+        @testset for order in (RingGrids.nested_order, RingGrids.matrix_order)
+            reordered = order(field)
+
+            # reordering all layers at once == reordering every 2D layer independently
+            for c in CartesianIndices(trailing_dims)
+                layer = Field(field.data[:, c], grid)
+                @test order(layer) == Field(reordered.data[:, c], grid)
+            end
+        end
+    end
+end

--- a/RingGrids/test/reverse.jl
+++ b/RingGrids/test/reverse.jl
@@ -85,7 +85,7 @@ end
         reverse!(field, dims = :lon)
         for (j, ring) in enumerate(eachring(grid))
             n = length(ring)
-            if hasoffset(Grid, nlat_half, j)
+            if RingGrids.hasoffset(Grid, nlat_half, j)
                 @test field[ring] == n:-1:1         # 1, 2, ..., n -> n, ..., 2, 1
             else
                 @test field[ring] == [1; n:-1:2]    # first point (on 0˚) stays

--- a/RingGrids/test/reverse.jl
+++ b/RingGrids/test/reverse.jl
@@ -40,3 +40,21 @@
         end
     end
 end
+
+@testset "Reverse n-dimensional fields" begin
+    @testset for Grid in (FullGaussianGrid, OctahedralGaussianGrid, HEALPixGrid)
+        grid = Grid(4)
+        @testset for trailing_dims in ((2,), (2, 3), (2, 3, 2))
+            field = rand(Float32, grid, trailing_dims...)
+            @testset for dims in (:lat, :lon)
+                reversed = reverse(field, dims = dims)
+
+                # reversing all layers at once == reversing every 2D layer independently
+                for c in CartesianIndices(trailing_dims)
+                    layer = Field(field.data[:, c], grid)
+                    @test reverse(layer, dims = dims) == Field(reversed.data[:, c], grid)
+                end
+            end
+        end
+    end
+end

--- a/RingGrids/test/reverse.jl
+++ b/RingGrids/test/reverse.jl
@@ -32,7 +32,10 @@
                 @test reverse!(grid2, dims = :longitude) == grid
                 @test reverse(reverse(grid, dims = :lon), dims = :lon) == grid
 
-                if k < 2
+                # reversing both dims == reversing the whole (flat) array, but only for
+                # grids where all rings have a longitudinal offset: without one the first
+                # point of each ring stays in place under reverse(dims = :lon)
+                if k < 2 && Grid in (OctaminimalGaussianGrid, OctaHEALPixGrid)
                     @test reverse(reverse(grid, dims = :lat), dims = :lon) == reverse(grid)
                     @test reverse(reverse(grid, dims = :lon), dims = :lat) == reverse(grid)
                 end
@@ -55,6 +58,47 @@ end
                     @test reverse(layer, dims = dims) == Field(reversed.data[:, c], grid)
                 end
             end
+        end
+    end
+end
+
+@testset "Reverse :lon mirrors at the 0˚ meridian" begin
+    @testset for Grid in (
+            FullGaussianGrid,
+            FullClenshawGrid,
+            FullHEALPixGrid,
+            FullOctaHEALPixGrid,
+            OctahedralGaussianGrid,
+            OctahedralClenshawGrid,
+            HEALPixGrid,
+            OctaHEALPixGrid,
+            OctaminimalGaussianGrid,
+        )
+
+        nlat_half = 4
+        grid = Grid(nlat_half)
+        field = zeros(grid)
+        for ring in eachring(grid)
+            field[ring] .= 1:length(ring)
+        end
+
+        reverse!(field, dims = :lon)
+        for (j, ring) in enumerate(eachring(grid))
+            n = length(ring)
+            if hasoffset(Grid, nlat_half, j)
+                @test field[ring] == n:-1:1         # 1, 2, ..., n -> n, ..., 2, 1
+            else
+                @test field[ring] == [1; n:-1:2]    # first point (on 0˚) stays
+            end
+        end
+
+        # mirror at 0˚ is only possible in-place because every ring's longitudes
+        # map onto themselves under λ -> (360 - λ) % 360
+        londs, _ = get_londlatds(grid)
+        for ring in eachring(grid)
+            lond = londs[ring]
+            mirrored = sort!([mod(360 - λ, 360) for λ in lond])
+            @test mirrored ≈ sort(lond)
         end
     end
 end

--- a/RingGrids/test/rotate.jl
+++ b/RingGrids/test/rotate.jl
@@ -31,3 +31,21 @@
         end
     end
 end
+
+@testset "Rotate n-dimensional fields" begin
+    @testset for Grid in (FullGaussianGrid, OctahedralGaussianGrid, HEALPixGrid)
+        grid = Grid(4)
+        @testset for trailing_dims in ((2,), (2, 3), (2, 3, 2))
+            field = rand(Float32, grid, trailing_dims...)
+            @testset for degree in (90, 180, 270)
+                rotated = rotate(field, degree)
+
+                # rotating all layers at once == rotating every 2D layer independently
+                for c in CartesianIndices(trailing_dims)
+                    layer = Field(field.data[:, c], grid)
+                    @test rotate(layer, degree) == Field(rotated.data[:, c], grid)
+                end
+            end
+        end
+    end
+end

--- a/RingGrids/test/scaling.jl
+++ b/RingGrids/test/scaling.jl
@@ -24,3 +24,19 @@
         end
     end
 end
+
+@testset "Scale coslat n-dimensional fields" begin
+    @testset for Grid in (FullGaussianGrid, OctahedralGaussianGrid, HEALPixGrid)
+        grid = Grid(4)
+        @testset for trailing_dims in ((2,), (2, 3), (2, 3, 2))
+            field = randn(Float64, grid, trailing_dims...)
+            scaled = RingGrids.scale_coslat(field)
+
+            # scaling all layers at once == scaling every 2D layer independently
+            for c in CartesianIndices(trailing_dims)
+                layer = Field(field.data[:, c], grid)
+                @test RingGrids.scale_coslat(layer) == Field(scaled.data[:, c], grid)
+            end
+        end
+    end
+end

--- a/SpeedyWeatherInternals/src/KernelLaunching/KernelLaunching.jl
+++ b/SpeedyWeatherInternals/src/KernelLaunching/KernelLaunching.jl
@@ -107,7 +107,7 @@ end
 
 """
 $(TYPEDSIGNATURES)
-Returns the `workgroup` and `worksize` for launching a kernel over a regular 3D array.
+Returns the `workgroup` and `worksize` for launching a kernel over a regular N-D array.
 """
 function work_layout(::Type{ArrayWorkOrder}, worksize::NTuple{N, Int}) where {N}
     return heuristic_workgroup(worksize...), worksize

--- a/SpeedyWeatherInternals/src/KernelLaunching/KernelLaunching.jl
+++ b/SpeedyWeatherInternals/src/KernelLaunching/KernelLaunching.jl
@@ -25,6 +25,13 @@ function heuristic_workgroup(Wx, Wy, Wz)
     return (min(Wx, cld(cld(256, minWy), minWz)), minWy, minWz)
 end
 
+function heuristic_workgroup(Wx, Wy, Wz, Ww)
+    minWw = min(Ww, 4)
+    minWz = min(Wz, 4)
+    minWy = min(Wy, 4)
+    return (min(Wx, cld(cld(cld(256, minWy), minWz), minWw)), minWy, minWz, minWw)
+end
+
 # WORK ORDER TYPES FOR TYPE-BASED DISPATCH
 """
 Abstract type for different work order patterns in kernel launching.
@@ -52,7 +59,7 @@ Work order for kernels over the diagonal of a (m+1)×m or m×m LowerTriangularAr
 struct DiagonalWorkOrder <: AbstractWorkOrder end
 
 """
-Work order for kernels over a regular 3D array.
+Work order for kernels over a regular N-D array.
 """
 struct ArrayWorkOrder <: AbstractWorkOrder end
 

--- a/docs/src/lowertriangularmatrices.md
+++ b/docs/src/lowertriangularmatrices.md
@@ -226,10 +226,12 @@ sums along the second dimension of the underlying vector, not of the full matrix
 ## Rotation of `LowerTriangularArray`
 
 `LowerTriangularArray`s are used to describe spherical harmonics. In that case each element
-represents the coefficient in fron of the respective harmonic describing a field on the sphere
+represents the coefficient in front of the respective harmonic describing a field on the sphere
 when transformed to grid space. We implement `rotate!` (and `rotate` for an allocating version)
 for `LowerTriangularArray` to rotate these coefficients in complex number space to represent
-a longitude rotation of the represented grid space field. For example start with
+a longitude rotation of the represented grid space field. In contrast to the grid-space
+`rotate!` (see [Rotate and reverse Fields](@ref)) which is restricted to multiples of 90˚,
+any rotation angle is possible in spectral space. For example start with
 
 ```@repl LowerTriangularArrays
 M = rand(LowerTriangularMatrix{ComplexF32}, 3, 3)
@@ -260,13 +262,15 @@ rotate!(M, 315)
 
 A `LowerTriangularArray` is an `AbstractArray`, as such `reverse` and `reverse!` (in-place) are defined,
 reversing all elements of these arrays in the way how they are indexed with a single index.
-For `LowerTriangularArra` representing the coefficients of the spherical harmonics this does not make
+For `LowerTriangularArray` representing the coefficients of the spherical harmonics this does not make
 much sense, however, we describe here the functionality to `reverse` these arrays as they represent
 spherical harmonics, adding methods for `dims=:lat` for reversal in latitude direction and `dims=:lon` in
 longitude direction. Spherical harmonics are reversed in latitude by flipping the sign of the
 odd harmonics, which are the ones that are not symmetric around the equator. Spherical harmonics are
 reversed in longitude by taking the complex conjugate of every element as this flips the sign of the
 imaginary parts, which effectively mirrors the rotation of that harmonic around 0˚E.
+Both are consistent with reversing the corresponding field in grid space,
+see [Rotate and reverse Fields](@ref).
 
 ```@repl LowerTriangularArrays
 reverse(M, dims=:lat)
@@ -345,7 +349,8 @@ Therefore, once you've initialized the `SpectralGrid`, you can create `LowerTria
 with the same spectral discretization as follows:
 
 ```@repl LowerTriangularArrays
-SG = SpectralGrid(trunc=31)
+using SpeedyWeather
+SG = SpectralGrid(trunc=5)
 L = rand(Float32, SG.spectrum)
 ```
 

--- a/docs/src/ringgrids.md
+++ b/docs/src/ringgrids.md
@@ -241,6 +241,37 @@ for k in eachlayer(field)           # loop over 2 x 3
 end
 ```
 
+## Rotate and reverse Fields
+
+A field can be rotated in longitude with `rotate!` (in-place) or `rotate` (allocating),
+shifting the data eastward along every ring. In grid space only rotations by multiples of
+90˚ are possible (all implemented grids have rings divisible by 4), negative degrees
+rotate westward
+
+```@example ringgrids
+field = randn(FullGaussianGrid(4))
+field2 = rotate(field, 90)      # rotate a copy 90˚ eastward
+rotate!(field2, 270)            # then 270˚ more in-place, back to the original
+field2 == field
+```
+
+For rotations by any angle use `rotate!` on the spectral coefficients, see
+[Rotation of `LowerTriangularArray`](@ref). A field can also be reversed in latitude
+(mirror at the equator) or longitude (mirror at the 0˚ meridian) with `reverse`/`reverse!`
+
+```@example ringgrids
+reverse(field, dims=:lat)       # mirror at the equator
+reverse!(field, dims=:lon)      # in-place, mirror at the 0˚ meridian
+nothing # hide
+```
+
+The mirror at 0˚ is possible in-place because every ring's longitudes map onto themselves
+under ``\lambda \to -\lambda``: on rings with a longitudinal offset (first point half a
+grid spacing east of 0˚, like the HEALPix-type grids) all points within a ring are reversed,
+on rings whose first point lies on 0˚ that point stays and only the remaining points are
+reversed. Both operations are therefore consistent with their counterparts acting on the
+spherical harmonic coefficients, see [Reverse of `LowerTriangularArray`](@ref).
+
 ## Interpolation between grids
 
 In most cases we will want to use RingGrids so that our data directly comes with the geometric information

--- a/docs/src/ringgrids.md
+++ b/docs/src/ringgrids.md
@@ -183,7 +183,7 @@ and [UnicodePlots's](https://github.com/JuliaPlots/UnicodePlots.jl)' `heatmap`, 
 [Visualisation via Makie](@ref) and [Visualisation via UnicodePlots](@ref).
 
 ```@example ringgrids
-using CairoMakie    # triggers loading of Makie extension, or do using UnicodePlots instead!
+import CairoMakie: heatmap   # triggers loading of Makie extension, or use UnicodePlots instead!
 grid = OctahedralGaussianGrid(24)
 field = randn(grid)
 heatmap(field)


### PR DESCRIPTION
Also fixes a bug whereby grids without offset had a dlon shift westwards when reversed, because

<img width="684" height="284" alt="image" src="https://github.com/user-attachments/assets/d93dd516-28ff-4688-833c-a75c0f2d0f73" />

So how to reverse a field in longitude depends on whether the field has an offset or not. 