### PR TITLE
Lower wind gust speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower free convection gust constant [#1178](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1178)
 - Add ocean neutral surface wind speed model [#1156](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1156)
 - Fix GPU inverse Legendre transform for single-layer spectral fields on GPU [#1173](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1173)
 - Revised extended differentiability tests [#1167](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1167)

--- a/SpeedyWeather/src/parameterizations/surface_fluxes/surface_condition.jl
+++ b/SpeedyWeather/src/parameterizations/surface_fluxes/surface_condition.jl
@@ -10,7 +10,7 @@ atmospheric relationships. Fields are $(TYPEDFIELDS)"""
     wind_slowdown::NF = 0.95
 
     "[OPTION] Wind speed of sub-grid scale gusts [m/s]"
-    gust_speed::NF = 5
+    gust_speed::NF = 1
 end
 
 Adapt.@adapt_structure SurfaceCondition


### PR DESCRIPTION
Lowering the gust speed constant from free convection to a more realistic value, from 5m/s to 1m/s.

This reduces the sensible heat flux over land, lowers rainfall over the ocean significantly and reduces surface temperatures everywhere.

<img width="1018" height="217" alt="Screenshot 2026-08-05 at 17 57 52" src="https://github.com/user-attachments/assets/3f6ae0d1-ef25-44bf-8b25-2118f9cfa990" />
