### PR TITLE
Add snow to Terrarium-SpeedyWeather coupling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update and fix bugs in SpeedyWeather + Terrarium coupling extension [#1188](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1188)
 - Fixes a `SpeedyWeather.animate` projection issue [#958](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/958)
 - [BREAKING] 1-based truncation as resolution parameter [#1177](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1177)
 - CUDA GPU CI is now run with Julia 1.12 [#1171](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1171)

--- a/SpeedyWeather/ext/SpeedyWeatherGeoMakieExt.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherGeoMakieExt.jl
@@ -95,7 +95,8 @@ function SpeedyWeather.animate(
     end
 
     # Check if the variable is 3D (has a vertical dimension)
-    is_3d = "layer" in dimnames(ds[variable])
+    var_dim_names = dimnames(ds[variable])
+    is_3d = "layer" in var_dim_names || "soil_layer" in var_dim_names
 
     # Create the figure
     fig = Figure(size = figure_size)

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/SpeedyWeatherTerrariumExt.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/SpeedyWeatherTerrariumExt.jl
@@ -2,6 +2,8 @@ module SpeedyWeatherTerrariumExt
 
 using SpeedyWeather
 using Terrarium
+
+using Dates
 using DocStringExtensions
 
 include("coupling.jl")

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
@@ -435,7 +435,7 @@ function SpeedyWeather.initialize!(
 
     # fill ocean/non-Terrarium points with fallback values first, then seed the land columns
     fill_fallback!(vars, land)
-    RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, interior(state.skin_temperature) .+ NF(273.15), indices)
+    RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, @view(interior(state.temperature)[:, 1, end]) .+ NF(273.15), indices)
     return nothing
 end
 

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
@@ -247,7 +247,7 @@ function TerrariumLand(
     )
 end
 
-function SpeedyWeather.variables(::AbstractTerrariumLandModel)
+function SpeedyWeather.variables(land_model::AbstractTerrariumLandModel)
     return (
         # The full Terrarium state, owned by SpeedyWeather's Variables tree.
         SpeedyWeather.PrognosticVariable(
@@ -258,6 +258,13 @@ function SpeedyWeather.variables(::AbstractTerrariumLandModel)
         # rest of SpeedyWeather (longwave/shortwave radiation, surface fluxes,
         # output writers) can read them. They are kept in sync from the
         # Terrarium state inside `initialize!` and `timestep!`.
+        SpeedyWeather.variables(land_model, land_model.model.soil)...,
+        SpeedyWeather.variables(land_model, land_model.model.snow)...,
+    )
+end
+
+function SpeedyWeather.variables(::AbstractTerrariumLandModel, ::Terrarium.AbstractSoil)
+    return (
         SpeedyWeather.PrognosticVariable(
             name = :soil_temperature, dims = SpeedyWeather.Grid2D(),
             units = "K", desc = "Soil temperature mirrored from Terrarium",
@@ -268,6 +275,11 @@ function SpeedyWeather.variables(::AbstractTerrariumLandModel)
             units = "1", desc = "Soil moisture (saturation fraction) mirrored from Terrarium",
             namespace = :land,
         ),
+    )
+end
+
+function SpeedyWeather.variables(::AbstractTerrariumLandModel, ::Terrarium.AbstratSnow)
+    return (
         SpeedyWeather.PrognosticVariable(
             name = :snow_depth, dims = SpeedyWeather.Grid2D(),
             units = "m", desc = "Snow depth water equivalent mirrored from Terrarium",
@@ -275,6 +287,8 @@ function SpeedyWeather.variables(::AbstractTerrariumLandModel)
         ),
     )
 end
+
+SpeedyWeather.variables(::AbstractTerrariumLandModel, ::Nothing) = ()
 
 # wet land model
 function SpeedyWeather.initialize!(
@@ -309,8 +323,15 @@ function SpeedyWeather.initialize!(
 
     # fill ocean/non-Terrarium points with fallback values first, then seed the land columns
     fill_fallback!(vars, land)
-    RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, Tsoil, indices)
-    RingGrids.copy_unmasked!(vars.prognostic.land.soil_moisture, sat, indices)
+    if haskey(vars.prognostic.land, :soil_temperature)
+        RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, Tsoil, indices)
+    end
+    if haskey(vars.prognostic.land, :soil_moisture)
+        RingGrids.copy_unmasked!(vars.prognostic.land.soil_moisture, sat, indices)
+    end
+    if haskey(vars.prognostic.land, :snow_depth)
+        RingGrids.copy_unmasked!(vars.prognostic.land.snow_depth, state.snow_water_equivalent, indices)
+    end
     return nothing
 end
 
@@ -366,8 +387,12 @@ function SpeedyWeather.timestep!(
     # `vars.prognostic.land.terrarium`; the soil mirrors are refreshed so
     # SpeedyWeather radiation / surface flux components see current values.
     # TODO: Use custom kernel to make the conversion from °C → K non-allocating here
-    RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, interior(state.skin_temperature) .+ NF(273.15), indices)
-    RingGrids.copy_unmasked!(vars.prognostic.land.soil_moisture, @view(interior(state.saturation_water_ice)[:, 1, end]), indices)
+    if haskey(vars.prognostic.land, :soil_temperature)
+        RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, interior(state.skin_temperature) .+ NF(273.15), indices)
+    end
+    if haskey(vars.prognostic.land, :soil_moisture)
+        RingGrids.copy_unmasked!(vars.prognostic.land.soil_moisture, @view(interior(state.saturation_water_ice)[:, 1, end]), indices)
+    end
     if haskey(vars.prognostic.land, :sensible_heat_flux)
         RingGrids.copy_unmasked!(vars.prognostic.land.sensible_heat_flux, state.sensible_heat_flux, indices)
     end
@@ -389,7 +414,7 @@ function SpeedyWeather.initialize!(
     )
     state = vars.prognostic.land.terrarium
     NF = eltype(vars.prognostic.land.soil_temperature)
-    mask = land_mask(land)
+    indices = land.mask_indices
 
     # Sync the Terrarium clock's initial time with the SpeedyWeather clock,
     # which was set from the `time` kwarg of `initialize!(model; time=...)`.
@@ -400,7 +425,7 @@ function SpeedyWeather.initialize!(
 
     # fill ocean/non-Terrarium points with fallback values first, then seed the land columns
     fill_fallback!(vars, land)
-    vars.prognostic.land.soil_temperature[mask] .= @view(interior(state.temperature)[:, 1, end]) .+ NF(273.15)
+    RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, interior(state.skin_temperature) .+ NF(273.15), indices)
     return nothing
 end
 

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
@@ -342,6 +342,11 @@ function SpeedyWeather.initialize!(
     if haskey(vars.prognostic.land, :snow_depth)
         RingGrids.copy_unmasked!(vars.prognostic.land.snow_depth, state.snow_water_equivalent, indices)
     end
+    # Push albedo only if present in Terrarium state (diagnostic albedo)
+    # TODO: implement haskey for Terrarium StateVariables
+    if hasproperty(state, :albedo)
+        RingGrids.copy_unmasked!(vars.parameterizations.land.albedo, state.albedo, indices)
+    end
     return nothing
 end
 
@@ -398,20 +403,25 @@ function SpeedyWeather.timestep!(
     # SpeedyWeather radiation / surface flux components see current values.
     # TODO: Use custom kernel to make the conversion from °C → K non-allocating here
     if haskey(vars.prognostic.land, :soil_temperature)
-        RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, interior(state.skin_temperature) .+ NF(273.15), indices)
+        # Speedy treats the uppermost soil layer as the "skin" (for now) so that's what we copy here
+        RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, @view(interior(state.skin_temperature)[:, 1, 1]) .+ NF(273.15), indices)
     end
     if haskey(vars.prognostic.land, :soil_moisture)
         RingGrids.copy_unmasked!(vars.prognostic.land.soil_moisture, @view(interior(state.saturation_water_ice)[:, 1, end]), indices)
     end
     if haskey(vars.prognostic.land, :sensible_heat_flux)
-        RingGrids.copy_unmasked!(vars.prognostic.land.sensible_heat_flux, state.sensible_heat_flux, indices)
+        RingGrids.copy_unmasked!(vars.prognostic.land.sensible_heat_flux, @view(interior(state.sensible_heat_flux)[:, 1, 1]), indices)
     end
     if haskey(vars.prognostic.land, :surface_humidity_flux)
-        RingGrids.copy_unmasked!(vars.prognostic.land.surface_humidity_flux, state.latent_heat_flux, indices)
+        RingGrids.copy_unmasked!(vars.prognostic.land.surface_humidity_flux, @view(interior(state.latent_heat_flux)[:, 1, 1]), indices)
         vars.prognostic.land.surface_humidity_flux.data ./= consts.thermodynamics.latent_heat_vaporization
     end
     if haskey(vars.prognostic.land, :snow_depth)
-        RingGrids.copy_unmasked!(vars.prognostic.land.snow_depth, state.snow_water_equivalent, indices)
+        RingGrids.copy_unmasked!(vars.prognostic.land.snow_depth, @view(interior(state.snow_water_equivalent)[:, 1, 1]), indices)
+    end
+    # Push albedo only if present in Terrarium state (diagnostic albedo)
+    if hasproperty(state, :albedo)
+        RingGrids.copy_unmasked!(vars.parameterizations.land.albedo, @view(interior(state.albedo)[:, 1, 1]), indices)
     end
     return nothing
 end

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
@@ -278,7 +278,7 @@ function SpeedyWeather.variables(::AbstractTerrariumLandModel, ::Terrarium.Abstr
     )
 end
 
-function SpeedyWeather.variables(::AbstractTerrariumLandModel, ::Terrarium.AbstratSnow)
+function SpeedyWeather.variables(::AbstractTerrariumLandModel, ::Terrarium.AbstractSnow)
     return (
         SpeedyWeather.PrognosticVariable(
             name = :snow_depth, dims = SpeedyWeather.Grid2D(),

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
@@ -204,7 +204,7 @@ SpeedyWeather spectral grid."""
 function TerrariumLand(
         spectral_grid::SpectralGrid,
         model::Terrarium.AbstractModel{NF};
-        inputs::Terarium.InputSource = Terrairum.InputSources(NF),
+        inputs::Terrarium.InputSource = Terrarium.InputSources(NF),
         boundary_conditions::NamedTuple = (;),
         initializers::NamedTuple = (;),
         fields::NamedTuple = (;),

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
@@ -25,13 +25,14 @@ function SpeedyWeather.allocate(::SpeedyWeather.AbstractVariable{TerrariumVars},
     # DateTime; the actual initial datetime is synced from the SpeedyWeather clock
     # in `initialize!(vars, land, model)` once the user-provided `time` has been
     # written there.
-    return Terrarium.StateVariables(
+    integrator = Terrarium.initialize(
         land.model;
         inputs = land.inputs,
         clock = Terrarium.Clock(time = SpeedyWeather.DEFAULT_DATE),
         boundary_conditions = land.boundary_conditions,
         fields = land.fields,
     )
+    return integrator.state
 end
 
 """$(TYPEDEF)
@@ -167,7 +168,7 @@ struct TerrariumLand{
         LG <: LandGeometry,
         TM <: Terrarium.AbstractModel{NF},
         BC <: NamedTuple,
-        IN <: Tuple,
+        IN <: Terrarium.InputSource,
         IT <: NamedTuple,
         FL <: NamedTuple,
         TT,
@@ -284,6 +285,7 @@ function SpeedyWeather.initialize!(
     state = vars.prognostic.land.terrarium
     NF = eltype(vars.prognostic.land.soil_temperature)
     mask = land_mask(land)
+    indices = land.mask_indices
 
     # Sync the Terrarium clock's initial time with the SpeedyWeather clock,
     # which was set from the `time` kwarg of `initialize!(model; time=...)`.
@@ -297,7 +299,7 @@ function SpeedyWeather.initialize!(
     Terrarium.initialize!(integrator)
 
     Tsoil = interior(state.temperature)[:, 1, end] .+ NF(273.15)
-    sat = interior(state.saturation_water_ice)[:, 1, end]
+    sat = @view interior(state.saturation_water_ice)[:, 1, end]
 
     @assert length(mask) == length(vars.prognostic.land.soil_temperature) "Terrarium land mask (length = $(length(mask))) does not span the full SpeedyWeather ring grid (length = $(length(vars.prognostic.land.soil_temperature)))."
     @assert count(mask) == length(Tsoil) "Number of Terrarium land columns (length = $(length(Tsoil))) does not match the number of land points in the mask (count = $(count(mask)))."
@@ -307,8 +309,8 @@ function SpeedyWeather.initialize!(
 
     # fill ocean/non-Terrarium points with fallback values first, then seed the land columns
     fill_fallback!(vars, land)
-    vars.prognostic.land.soil_temperature[mask] .= Tsoil
-    vars.prognostic.land.soil_moisture[mask] .= sat
+    RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, Tsoil, indices)
+    RingGrids.copy_unmasked!(vars.prognostic.land.soil_moisture, sat, indices)
     return nothing
 end
 
@@ -321,7 +323,6 @@ function SpeedyWeather.timestep!(
     tmodel = land.model
     consts = tmodel.constants
     NF = eltype(state)
-    mask = land_mask(land)
     indices = land.mask_indices
     nlayers = model.spectral_grid.nlayers
 
@@ -364,7 +365,8 @@ function SpeedyWeather.timestep!(
     # The Terrarium state itself is mutated in place above and remains in
     # `vars.prognostic.land.terrarium`; the soil mirrors are refreshed so
     # SpeedyWeather radiation / surface flux components see current values.
-    RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, state.skin_temperature + NF(273.15), indices)
+    # TODO: Use custom kernel to make the conversion from °C → K non-allocating here
+    RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, interior(state.skin_temperature) .+ NF(273.15), indices)
     RingGrids.copy_unmasked!(vars.prognostic.land.soil_moisture, @view(interior(state.saturation_water_ice)[:, 1, end]), indices)
     if haskey(vars.prognostic.land, :sensible_heat_flux)
         RingGrids.copy_unmasked!(vars.prognostic.land.sensible_heat_flux, state.sensible_heat_flux, indices)
@@ -427,7 +429,7 @@ function SpeedyWeather.timestep!(
         state.clock, land_model, InputSources(NF),
         state, land.initializers,
     )
-    Terrarium.run!(integrator; period = vars.prognostic.clock.Δt, Δt = land.Δt)
+    Terrarium.run!(integrator; period = vars.prognostic.clock.Δt, Δt = land.Δt, show_progress = false)
 
     # Surface soil temperature from the bottom of the column (last z-index)
     vars.prognostic.land.soil_temperature[mask] .= @view(interior(state.temperature)[:, 1, end]) .+ NF(273.15)

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
@@ -27,9 +27,9 @@ function SpeedyWeather.allocate(::SpeedyWeather.AbstractVariable{TerrariumVars},
     # written there.
     return Terrarium.StateVariables(
         land.model;
+        inputs = land.inputs,
         clock = Terrarium.Clock(time = SpeedyWeather.DEFAULT_DATE),
         boundary_conditions = land.boundary_conditions,
-        input_variables = land.input_variables,
         fields = land.fields,
     )
 end
@@ -167,8 +167,8 @@ struct TerrariumLand{
         LG <: LandGeometry,
         TM <: Terrarium.AbstractModel{NF},
         BC <: NamedTuple,
-        IV <: Tuple,
-        IN <: NamedTuple,
+        IN <: Tuple,
+        IT <: NamedTuple,
         FL <: NamedTuple,
         TT,
         MI,
@@ -181,10 +181,10 @@ struct TerrariumLand{
     model::TM
     "Boundary conditions forwarded to `Terrarium.initialize`"
     boundary_conditions::BC
-    "Additional input variables forwarded to `Terrarium.initialize`"
-    input_variables::IV
+    "Terrarium `InputSource`s forwarded to `Terrarium.initialize`"
+    inputs::IN
     "Field initializers forwarded to the on-the-fly `ModelIntegrator`"
-    initializers::IN
+    initializers::IT
     "Preconstructed Terrarium fields forwarded to `Terrarium.initialize`"
     fields::FL
     "Terrarium-internal sub-step (seconds) used to integrate within each SpeedyWeather step"
@@ -204,8 +204,8 @@ SpeedyWeather spectral grid."""
 function TerrariumLand(
         spectral_grid::SpectralGrid,
         model::Terrarium.AbstractModel{NF};
+        inputs::Terarium.InputSource = Terrairum.InputSources(NF),
         boundary_conditions::NamedTuple = (;),
-        input_variables::Tuple = (),
         initializers::NamedTuple = (;),
         fields::NamedTuple = (;),
         Δt = Minute(5),
@@ -224,7 +224,7 @@ function TerrariumLand(
     Δt = isa(Δt, Number) ? NF(Δt) : Δt
     return TerrariumLand(
         spectral_grid, geometry, model,
-        boundary_conditions, input_variables, initializers, fields, Δt, mask_indices,
+        boundary_conditions, inputs, initializers, fields, Δt, mask_indices,
         NF(ocean_temperature), NF(ocean_moisture),
     )
 end

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
@@ -55,7 +55,7 @@ on this abstract type:
   copies soil temperatures, moisture and surface fluxes back into the
   SpeedyWeather variables.
 """
-abstract type AbstractTerrariumLandModel <: SpeedyWeather.AbstractLand end
+abstract type AbstractTerrariumLandModel{NF, TM} <: SpeedyWeather.AbstractLand end
 
 @inline SpeedyWeather.get_nlayers(land::AbstractTerrariumLandModel) = land.geometry.nlayers
 
@@ -173,7 +173,7 @@ struct TerrariumLand{
         FL <: NamedTuple,
         TT,
         MI,
-    } <: AbstractTerrariumLandModel
+    } <: AbstractTerrariumLandModel{NF, TM}
     "SpeedyWeather spectral grid"
     spectral_grid::SpectralGrid
     "SpeedyWeather land geometry (a single effective surface layer)"
@@ -247,17 +247,27 @@ function TerrariumLand(
     )
 end
 
-function SpeedyWeather.variables(land_model::AbstractTerrariumLandModel)
+function SpeedyWeather.variables(land_model::AbstractTerrariumLandModel{NF, <:Terrarium.SoilModel}) where {NF}
     return (
         # The full Terrarium state, owned by SpeedyWeather's Variables tree.
         SpeedyWeather.PrognosticVariable(
             name = :terrarium, dims = TerrariumVars(),
             namespace = :land, desc = "Terrarium land state",
         ),
-        # Thin grid-side mirrors of surface soil temperature / moisture so the
+        # Thin grid-side mirrors of land state variables so the
         # rest of SpeedyWeather (longwave/shortwave radiation, surface fluxes,
         # output writers) can read them. They are kept in sync from the
         # Terrarium state inside `initialize!` and `timestep!`.
+        SpeedyWeather.variables(land_model, land_model.model.soil)...,
+    )
+end
+
+function SpeedyWeather.variables(land_model::AbstractTerrariumLandModel{NF, <:Terrarium.LandModel}) where {NF}
+    return (
+        SpeedyWeather.PrognosticVariable(
+            name = :terrarium, dims = TerrariumVars(),
+            namespace = :land, desc = "Terrarium land state",
+        ),
         SpeedyWeather.variables(land_model, land_model.model.soil)...,
         SpeedyWeather.variables(land_model, land_model.model.snow)...,
     )

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
@@ -1,4 +1,3 @@
-
 """
 $(TYPEDSIGNATURES)
 
@@ -146,12 +145,14 @@ end
 @inline SpeedyWeather.RingGrids.copy_unmasked!(
     dest::Terrarium.Oceananigans.AbstractField,
     src::SpeedyWeather.AbstractField,
-    indices) = SpeedyWeather.RingGrids.copy_unmasked!(interior(dest), src, indices)
+    indices
+) = SpeedyWeather.RingGrids.copy_unmasked!(interior(dest), src, indices)
 
 @inline SpeedyWeather.RingGrids.copy_unmasked!(
-    dest::SpeedyWeather.AbstractField, 
+    dest::SpeedyWeather.AbstractField,
     src::Terrarium.Oceananigans.AbstractField,
-    indices) = SpeedyWeather.RingGrids.copy_unmasked!(dest, interior(src), indices)
+    indices
+) = SpeedyWeather.RingGrids.copy_unmasked!(dest, interior(src), indices)
 
 """$(TYPEDEF)
 
@@ -169,6 +170,7 @@ struct TerrariumLand{
         IV <: Tuple,
         IN <: NamedTuple,
         FL <: NamedTuple,
+        TT,
         MI,
     } <: AbstractTerrariumLandModel
     "SpeedyWeather spectral grid"
@@ -186,7 +188,7 @@ struct TerrariumLand{
     "Preconstructed Terrarium fields forwarded to `Terrarium.initialize`"
     fields::FL
     "Terrarium-internal sub-step (seconds) used to integrate within each SpeedyWeather step"
-    Δt::NF
+    Δt::TT
     "Indices of the common land sea mask, used for allocation-free copying between SpeedyWeather and Terrarium"
     mask_indices::MI
     "Fallback soil temperature [K] for grid points outside the Terrarium land mask (ocean-only cells)"
@@ -206,7 +208,7 @@ function TerrariumLand(
         input_variables::Tuple = (),
         initializers::NamedTuple = (;),
         fields::NamedTuple = (;),
-        Δt::Real = 300,
+        Δt = Minute(5),
         ocean_temperature::Real = 285,
         ocean_moisture::Real = 0,
     ) where {NF}
@@ -219,9 +221,10 @@ function TerrariumLand(
     # `unmasked_indices` treats `true` as masked-out; `model.grid.mask` is `true` at land
     # points, so invert it to get the indices of the (unmasked) land columns.
     mask_indices = RingGrids.unmasked_indices(.!model.grid.mask)
+    Δt = isa(Δt, Number) ? NF(Δt) : Δt
     return TerrariumLand(
         spectral_grid, geometry, model,
-        boundary_conditions, input_variables, initializers, fields, NF(Δt), mask_indices,
+        boundary_conditions, input_variables, initializers, fields, Δt, mask_indices,
         NF(ocean_temperature), NF(ocean_moisture),
     )
 end
@@ -262,6 +265,11 @@ function SpeedyWeather.variables(::AbstractTerrariumLandModel)
         SpeedyWeather.PrognosticVariable(
             name = :soil_moisture, dims = SpeedyWeather.Grid2D(),
             units = "1", desc = "Soil moisture (saturation fraction) mirrored from Terrarium",
+            namespace = :land,
+        ),
+        SpeedyWeather.PrognosticVariable(
+            name = :snow_depth, dims = SpeedyWeather.Grid2D(),
+            units = "m", desc = "Snow depth water equivalent mirrored from Terrarium",
             namespace = :land,
         ),
     )
@@ -365,11 +373,8 @@ function SpeedyWeather.timestep!(
         RingGrids.copy_unmasked!(vars.prognostic.land.surface_humidity_flux, state.latent_heat_flux, indices)
         vars.prognostic.land.surface_humidity_flux.data ./= consts.thermodynamics.latent_heat_vaporization
     end
-    if haskey(vars.parameterizations, :surface_longwave_up)
-        RingGrids.copy_unmasked!(vars.parameterizations.surface_longwave_up, state.surface_longwave_up, indices)
-    end
-    if haskey(vars.parameterizations, :surface_shortwave_up)
-        RingGrids.copy_unmasked!(vars.parameterizations.surface_shortwave_up, state.surface_shortwave_up, indices)
+    if haskey(vars.prognostic.land, :snow_depth)
+        RingGrids.copy_unmasked!(vars.prognostic.land.snow_depth, state.snow_water_equivalent, indices)
     end
     return nothing
 end

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
@@ -464,7 +464,7 @@ function SpeedyWeather.timestep!(
         state.clock, land_model, InputSources(NF),
         state, land.initializers,
     )
-    Terrarium.run!(integrator; period = vars.prognostic.clock.Δt, Δt = land.Δt, show_progress = false)
+    Terrarium.run!(integrator; period = vars.prognostic.clock.Δt, Δt = land.Δt)
 
     # Surface soil temperature from the bottom of the column (last z-index)
     vars.prognostic.land.soil_temperature[mask] .= @view(interior(state.temperature)[:, 1, end]) .+ NF(273.15)

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
@@ -364,8 +364,8 @@ function SpeedyWeather.timestep!(
     # The Terrarium state itself is mutated in place above and remains in
     # `vars.prognostic.land.terrarium`; the soil mirrors are refreshed so
     # SpeedyWeather radiation / surface flux components see current values.
-    vars.prognostic.land.soil_temperature[mask] .= interior(state.skin_temperature) .+ NF(273.15)
-    vars.prognostic.land.soil_moisture[mask] .= @view interior(state.saturation_water_ice)[:, 1, end]
+    RingGrids.copy_unmasked!(vars.prognostic.land.soil_temperature, state.skin_temperature + NF(273.15), indices)
+    RingGrids.copy_unmasked!(vars.prognostic.land.soil_moisture, @view(interior(state.saturation_water_ice)[:, 1, end]), indices)
     if haskey(vars.prognostic.land, :sensible_heat_flux)
         RingGrids.copy_unmasked!(vars.prognostic.land.sensible_heat_flux, state.sensible_heat_flux, indices)
     end

--- a/SpeedyWeather/test/parameterizations/terrarium_coupling.jl
+++ b/SpeedyWeather/test/parameterizations/terrarium_coupling.jl
@@ -105,8 +105,8 @@ end
 
     land = SpeedyWeather.LandModel(
         spectral_grid, soil_model;
+        inputs = Tair_input,
         boundary_conditions = bcs,
-        input_variables = Terrarium.variables(Tair_input),
         Δt = 300.0,
     )
     @test land isa AbstractTerrariumLandModel


### PR DESCRIPTION
Updates `SpeedyWeatherTerrariumExt` to include snow depth water equivalent (SWE) and albedo. Also fixes broken GPU compatibility.

## TODO
- [x] Add SWE coupling (when `snow` is present in `LandModel`)
- [x] Add albedo coupling using #1186 
- [x] Fix GPU compat
- [x] Bonus finally fix #1189 