### PR TITLE
Work around AMDGPU/LLVM miscompile of triangular loop in implicit kernel

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,7 @@ steps:
     matrix:
       setup:
         version:
-          - "1.12"
+          - "1.11"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,7 @@ steps:
     matrix:
       setup:
         version:
-          - "1.11"
+          - "1.12"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Work around an AMDGPU/LLVM miscompile of a triangular loop with dynamic bounds in the semi-implicit primitive-equation kernel [#1193](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1193)
+- Add implementation of `cat` for `RingGrids` `Field`s [#1192](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1192)
 
 ## v0.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Work around an AMDGPU/LLVM miscompile of a triangular loop with dynamic bounds in the semi-implicit primitive-equation kernel [#1193](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1193)
+
 ## v0.22.0
 
 - [BREAKING] 1-based truncation as resolution parameter [#1177](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1177)

--- a/SpeedyWeather/src/time_stepping/implicit/implicit_primitive_equations.jl
+++ b/SpeedyWeather/src/time_stepping/implicit/implicit_primitive_equations.jl
@@ -301,8 +301,13 @@ end
     for k in 1:nlayers
         # skip 1:k-1 as integration is surface to k
         geopotential_val = zero(eltype(geopotential))
-        for r in k:nlayers
+        # while loop instead of `for r in k:nlayers`: the triangular range with both
+        # endpoints dynamic miscompiles on AMDGPU/CDNA (gfx90a/gfx942), see
+        # https://github.com/JuliaGPU/AMDGPU.jl/issues/1015
+        r = k
+        while r <= nlayers
             geopotential_val += R[k, r] * temp_tend[lm, r]
+            r += 1
         end
         geopotential[lm, k] = geopotential_val
     end


### PR DESCRIPTION
Implementation of Ludovic's suggested work around for bug reported in https://github.com/JuliaGPU/AMDGPU.jl/issues/1015 for `implicit_primitive_leapfrog_kernel!` I did not find any other kernel that is affected by this pattern.

The bug has already been fixed in https://github.com/llvm/llvm-project/pull/215829 However, it may still take quite some time until it gets integrated it in a new version. 