### PR TITLE
replace deprecated trunc keyword with truncation in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Resolve `trunc` deprecation warnings in the test suite [#XXXX](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/XXXX)
+- Resolve `trunc` deprecation warnings in the test suite [#1197](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1197)
 - Add implementation of `cat` for `RingGrids` `Field`s [#1192](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1192)
 
 ## v0.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Resolve `trunc` deprecation warnings in the test suite [#XXXX](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/XXXX)
 - Add implementation of `cat` for `RingGrids` `Field`s [#1192](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1192)
 
 ## v0.22.0

--- a/SpeedyWeather/test/GPU/spectral_transform.jl
+++ b/SpeedyWeather/test/GPU/spectral_transform.jl
@@ -191,8 +191,8 @@ end
     NF = Float32
     @testset for Grid in (FullGaussianGrid, OctahedralGaussianGrid)
         @testset for nlayers in (1, 4)
-            spectral_grid_cpu = SpectralGrid(; NF, trunc = 31, nlayers, Grid)
-            spectral_grid_gpu = SpectralGrid(; NF, trunc = 31, nlayers, Grid, architecture = SpeedyWeather.GPU)
+            spectral_grid_cpu = SpectralGrid(; NF, truncation = 32, nlayers, Grid)
+            spectral_grid_gpu = SpectralGrid(; NF, truncation = 32, nlayers, Grid, architecture = SpeedyWeather.GPU)
             S_cpu = SpectralTransform(spectral_grid_cpu)
             S_gpu = SpectralTransform(spectral_grid_gpu)
             cpu_arch = S_cpu.architecture
@@ -252,8 +252,8 @@ end
     # forward kernel therefore reads its rings from a table rather than assuming their extent.
     @testset "non-monotonic Legendre shortcut" begin
         NF, nlayers, LegendreShortcut = Float32, 2, SpeedyTransforms.LegendreShortcutLinCubCoslat
-        spectral_grid_cpu = SpectralGrid(; NF, trunc = 31, nlayers, Grid = HEALPixGrid)
-        spectral_grid_gpu = SpectralGrid(; NF, trunc = 31, nlayers, Grid = HEALPixGrid, architecture = SpeedyWeather.GPU)
+        spectral_grid_cpu = SpectralGrid(; NF, truncation = 32, nlayers, Grid = HEALPixGrid)
+        spectral_grid_gpu = SpectralGrid(; NF, truncation = 32, nlayers, Grid = HEALPixGrid, architecture = SpeedyWeather.GPU)
         S_cpu = SpectralTransform(spectral_grid_cpu; LegendreShortcut)
         S_gpu = SpectralTransform(spectral_grid_gpu; LegendreShortcut)
         cpu_arch = S_cpu.architecture

--- a/SpeedyWeather/test/dynamics/forcing_drag.jl
+++ b/SpeedyWeather/test/dynamics/forcing_drag.jl
@@ -46,7 +46,7 @@ end
     # (Fu, Fv) = -c*max(0, |(u,v)| - speed_limit)^2 * (u,v)/|(u,v)|, i.e. it decelerates the
     # flow without rotating it. The previous (sign(u), sign(v)) form pointed along the quadrant
     # diagonal instead and was √2 too large for a 45° flow.
-    spectral_grid = SpectralGrid(trunc = 15, nlayers = 2)
+    spectral_grid = SpectralGrid(truncation = 16, nlayers = 2)
     c, speed_limit = 3.0e-6, 80.0
     drag = SpeedLimitDrag(spectral_grid; drag = c, speed_limit)
     model = PrimitiveDryModel(spectral_grid; drag)

--- a/SpeedyWeather/test/dynamics/horizontal_diffusion.jl
+++ b/SpeedyWeather/test/dynamics/horizontal_diffusion.jl
@@ -48,7 +48,7 @@ end
     # solution var_new = (var + Δt*tend)/(1 - Δt*expl). Any other factor over- or
     # under-damps the full tendency, not just the diffusion.
     @testset for HD in (HyperDiffusion, SpectralFilter)
-        spectral_grid = SpectralGrid(trunc = 31, nlayers = 4)
+        spectral_grid = SpectralGrid(truncation = 32, nlayers = 4)
         horizontal_diffusion = HD(spectral_grid)
         model = PrimitiveWetModel(spectral_grid; horizontal_diffusion)
         simulation = initialize!(model)


### PR DESCRIPTION
Replaces deprecated `trunc` keyword with `truncation` in tests.

This is just a tiny fix.  After looking at the GPU test suite for that long, I decided to get rid of these warnings. 