### PR TITLE
Fix faulty handling of `InputSource`s in Terrarium extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Work around an AMDGPU/LLVM miscompile of a triangular loop with dynamic bounds in the semi-implicit primitive-equation kernel [#1193](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1193)
 - Resolve `trunc` deprecation warnings in the test suite [#1197](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1197)
 - Add implementation of `cat` for `RingGrids` `Field`s [#1192](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1192)
+- Fix faulty handling of `InputSource`s in Terrarium extension [#1199](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1199)
 
 ## v0.22.0
 

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/coupling.jl
@@ -388,11 +388,9 @@ function SpeedyWeather.timestep!(
     RingGrids.copy_unmasked!(inputs.surface_longwave_down, Rld, indices)
 
     # Constructing ModelIntegrator is allocation-free: it is an immutable struct
-    # of references so no data is copied.  `InputSources` is empty intentionally:
-    # we own the input-update cycle above (via set!) and do not want Terrarium's
-    # update_inputs! to overwrite those values during the substeps.
+    # of references so no data is copied.
     integrator = ModelIntegrator(
-        state.clock, tmodel, InputSources(NF),
+        state.clock, tmodel, land.inputs,
         state, land.initializers,
     )
     Terrarium.run!(integrator; period = vars.prognostic.clock.Δt, Δt = land.Δt)

--- a/SpeedyWeather/src/time_stepping/clock.jl
+++ b/SpeedyWeather/src/time_stepping/clock.jl
@@ -25,7 +25,7 @@ $(TYPEDFIELDS)"""
 
     "Number of time stepper steps, regardless their step size"
     n_steps::I = 0
-    
+
     "Number of time steps of size Δt"
     n_time_steps::I = 0
 
@@ -196,14 +196,14 @@ Dates.second(x::Dates.Nanosecond) = round(Int, x.value * 1.0e-9)
 Dates.second(x::Dates.Microsecond) = round(Int, x.value * 1.0e-6)
 Dates.second(x::Dates.Millisecond) = round(Int, x.value * 1.0e-3)
 
-# defined to convert from floats to Second (which require ints by default) via rounding
+# defined to convert from floats to Second (which require integers by default) via rounding
 function Base.convert(::Type{Second}, x::AbstractFloat)
     xr = round(Int64, x)
     x == xr || @warn "Rounding and converting $x to $xr for integer seconds."
     return Second(xr)
 end
 
-# conversion rule that allows integers to be autmoatically converted into Seconds
+# conversion rule that allows integers to be automatically converted into Seconds
 function Base.convert(::Type{Second}, x::Integer)
     @warn "Input '$x' assumed to have units of seconds. Use Minute($x), Hour($x), or Day($x) otherwise."
     return Second(round(Int64, x))


### PR DESCRIPTION
The current implementation wrongly ignored user-configured input sources under the pretense that Speedy would provide *all* inputs, which is obviously false.