### PR TITLE
Update Terrarium output writer to handle new variable containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update Terrarium output writer to work with v0.1.6 [#1224](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1224)
 - Fix GPU scalar indexing when a `Field` broadcasts against a bare GPU array (e.g. `LinearDrag` in the Held-Suarez example) [#1219](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1219)
 - Reformulate trigonometric functions to avoid hostcalls on AMDGPU - [#1210](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1210)
 

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/output.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/output.jl
@@ -148,8 +148,8 @@ function SpeedyWeather.TerrariumOutput(
         kwargs...
     )
     descriptors = variable_descriptors(model; prognostic, auxiliary, inputs)
-    supported = filter(supported_variable, values(descriptors))
-    return Tuple(terrarium_output_variable(model, descriptor; kwargs...) for descriptor in supported)
+    supported = filter(supported_variable, Tuple(values(descriptors)))
+    return map(descriptor -> terrarium_output_variable(model, descriptor; kwargs...), supported)
 end
 
 # convenience: construct directly from the SpeedyWeather land component

--- a/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/output.jl
+++ b/SpeedyWeather/ext/SpeedyWeatherTerrariumExt/output.jl
@@ -93,20 +93,22 @@ function terrarium_output_variable(
     )
 end
 
-# name-keyed NamedTuple of all top-level Terrarium variable descriptors of the
-# selected groups; prognostic variables take precedence over auxiliary and input
-# duplicates of the same name (as does `getproperty` on the Terrarium state)
+"""
+Return a name-keyed OrderedDict of all top-level Terrarium variable descriptors of the
+selected groups; prognostic variables take precedence over auxiliary and input
+duplicates of the same name (as does `getproperty` on the Terrarium state)
+"""
 function variable_descriptors(
         model::Terrarium.AbstractModel;
         prognostic::Bool = true,
         auxiliary::Bool = true,
         inputs::Bool = false,
     )
-    tvars = Terrarium.Variables(Terrarium.variables(model))
+    terrarium_vars = Terrarium.Variables(model)
     return merge(
-        inputs ? tvars.inputs : (;),
-        auxiliary ? tvars.auxiliary : (;),
-        prognostic ? tvars.prognostic : (;),
+        inputs ? terrarium_vars.inputs : empty(terrarium_vars.inputs),
+        auxiliary ? terrarium_vars.auxiliary : empty(terrarium_vars.auxiliary),
+        prognostic ? terrarium_vars.prognostic : empty(terrarium_vars.prognostic),
     )
 end
 
@@ -146,7 +148,7 @@ function SpeedyWeather.TerrariumOutput(
         kwargs...
     )
     descriptors = variable_descriptors(model; prognostic, auxiliary, inputs)
-    supported = filter(supported_variable, collect(descriptors))
+    supported = filter(supported_variable, values(descriptors))
     return Tuple(terrarium_output_variable(model, descriptor; kwargs...) for descriptor in supported)
 end
 


### PR DESCRIPTION
Terrarium v0.1.6 broke the SpeedyWeather extension output writer because the  `Variables` container now uses `OrderedDict`s instead of `NamedTuple`s. This PR updates the output writer to work with the new format. It should also be backwards compatible with older Terrarium versions, but this is not tested.