### PR TITLE
move gpu_graphs to /src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Move `gpu_graphs_common.jl` from `SpeedyTransforms/ext/` to `SpeedyTransforms/src/` for organizational purposes; still only `include()`-d from the CUDA/AMDGPU extensions, never from `SpeedyTransforms.jl`, so behavior is unchanged [#TODO](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/TODO)
 - Extract the backend-agnostic parts of GPU-graphs acceleration (kernels, cache, capture/replay control flow) into a shared `gpu_graphs_common.jl`, `include()`-d by both the CUDA and AMDGPU extensions [#1147](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1147)
 - Restrist Reactant compat to 0.2.279 [#1206](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1206)
 - Simulation(model) as Oceananigans-like interface [#1205](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1205)

--- a/SpeedyTransforms/ext/SpeedyTransformsAMDGPUExt.jl
+++ b/SpeedyTransforms/ext/SpeedyTransformsAMDGPUExt.jl
@@ -43,7 +43,7 @@ import SpeedyWeatherInternals.Architectures: on_architecture, GPU
 # and test on real hardware before trusting it.
 # =====================================================================================
 
-include("gpu_graphs_common.jl")
+include("../src/gpu_graphs_common.jl")
 
 # Probe for the high-level HIP graph API. AMDGPU.HIP exports these in newer versions; on
 # older installs only the raw C bindings (hipGraph_t, hipGraphExec_t, …) are present.

--- a/SpeedyTransforms/ext/SpeedyTransformsCUDAExt.jl
+++ b/SpeedyTransforms/ext/SpeedyTransformsCUDAExt.jl
@@ -51,7 +51,7 @@ import SpeedyWeatherInternals.Architectures: on_architecture, GPU
 # backend (see `GraphBackend`).
 # =====================================================================================
 
-include("gpu_graphs_common.jl")
+include("../src/gpu_graphs_common.jl")
 
 # The CUDA capture/instantiate/launch primitives `run_graph!` needs, plus the architecture
 # used to `synchronize` before capture; see `GraphBackend` in gpu_graphs_common.jl. `capture`

--- a/SpeedyTransforms/src/gpu_graphs_common.jl
+++ b/SpeedyTransforms/src/gpu_graphs_common.jl
@@ -2,11 +2,8 @@
 # BACKEND-AGNOSTIC GPU-GRAPHS MACHINERY FOR THE BATCHED FOURIER TRANSFORM
 #
 # `include()`-d by each graph-capturing backend extension (currently SpeedyTransformsCUDAExt.jl
-# and SpeedyTransformsAMDGPUExt.jl). See SpeedyTransformsCUDAExt.jl for the rationale of
-# GPU-graphs acceleration itself.
-#
-# TODO: This code ended up in src/ by accident once and reportedly broke Enzyme's CPU-only 
-# autodiff tests. Confirm and fix underlying issue.
+# and SpeedyTransformsAMDGPUExt.jl) via a relative-path include, NOT by SpeedyTransforms.jl
+# itself. See SpeedyTransformsCUDAExt.jl for the rationale of GPU-graphs acceleration itself.
 #
 # The only thing that differs between backends is the graph capture/instantiate/launch API
 # itself (e.g. `CUDA.capture`/`instantiate`/`launch` vs a HIP equivalent) and the graph-exec


### PR DESCRIPTION
While going through #1147 again I noticed that both Milan  (https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1147#discussion_r3803411741) and Maximilian (https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1147#issuecomment-5327716605) suggested to put `gpu_graphs_common,jl` into `SpeedyTransforms` directly.

I forgot to do that in #1147 so here is the change as suggested. This is purely cosmetic, so feel free to ignore. I will only ask for reviews if the tests pass first.  