### PR TITLE
Add GPU-safe `clamp!` for `Field`, make `fill!` return a `Field`, only clamp land-sea mask when out of range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add GPU-safe `clamp!` and make `fill!` return a `Field` for `AbstractField`, and only clamp the land-sea mask when out of range [#1228](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1228)
 - Remove Reactant compat restriction again [#1225](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1225)
 - Remove Reactant from SpeedyWeather/test/GPU/AMDGPU/Project.toml for AMDGPU compatibility with Julia v1.12 [#1193](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1193)
 - Avoid `isodd(::AbstractFloat)`'s exact-integer-conversion fallback (an `InexactError` throw path) in `mod(::Particle)`, which triggered AMDGPU hostcalls [#1220](https://github.com/SpeedyWeather/SpeedyWeather.jl/pull/1220)

--- a/RingGrids/src/field.jl
+++ b/RingGrids/src/field.jl
@@ -123,10 +123,10 @@ matrix_size(field::AbstractField) = (matrix_size(field.grid)..., size(field)[2:e
 # simply propagate all indices forward
 Base.@propagate_inbounds Base.getindex(field::AbstractField, ijk...) = getindex(field.data, ijk...)
 Base.@propagate_inbounds Base.setindex!(field::AbstractField, x, ijk...) = setindex!(field.data, x, ijk...)
-Base.fill!(field::AbstractField, x) = Field(fill!(field.data, x), field.grid, field.dims)
+Base.fill!(field::AbstractField, x) = nonparametric_type(typeof(field))(fill!(field.data, x), field.grid, field.dims)
 
 # defined explicitly as the generic AbstractArray fallback uses scalar indexing, which errors on GPU
-Base.clamp!(F::AbstractField, lo, hi) = Field(clamp!(F.data, lo, hi), F.grid, F.dims)
+Base.clamp!(field::AbstractField, lo, hi) = nonparametric_type(typeof(field))(clamp!(field.data, lo, hi), field.grid, field.dims)
 
 # make [:, k...] not escape the Field
 @inline Base.getindex(field::AbstractField, col::Colon, k...) = Field(field.data[col, k...], field.grid, field.dims[col, k...])

--- a/RingGrids/src/field.jl
+++ b/RingGrids/src/field.jl
@@ -123,7 +123,10 @@ matrix_size(field::AbstractField) = (matrix_size(field.grid)..., size(field)[2:e
 # simply propagate all indices forward
 Base.@propagate_inbounds Base.getindex(field::AbstractField, ijk...) = getindex(field.data, ijk...)
 Base.@propagate_inbounds Base.setindex!(field::AbstractField, x, ijk...) = setindex!(field.data, x, ijk...)
-Base.fill!(field::AbstractField, x) = nonparametric_type(typeof(field))(fill!(field.data, x), field.grid, field.dims)
+function Base.fill!(field::AbstractField, x) 
+                  fill!(field.data, x)
+                  return field
+end 
 
 # defined explicitly as the generic AbstractArray fallback uses scalar indexing, which errors on GPU
 Base.clamp!(field::AbstractField, lo, hi) = nonparametric_type(typeof(field))(clamp!(field.data, lo, hi), field.grid, field.dims)

--- a/RingGrids/src/field.jl
+++ b/RingGrids/src/field.jl
@@ -123,7 +123,10 @@ matrix_size(field::AbstractField) = (matrix_size(field.grid)..., size(field)[2:e
 # simply propagate all indices forward
 Base.@propagate_inbounds Base.getindex(field::AbstractField, ijk...) = getindex(field.data, ijk...)
 Base.@propagate_inbounds Base.setindex!(field::AbstractField, x, ijk...) = setindex!(field.data, x, ijk...)
-Base.fill!(field::AbstractField, x) = fill!(field.data, x)
+Base.fill!(field::AbstractField, x) = Field(fill!(field.data, x), field.grid, field.dims)
+
+# defined explicitly as the generic AbstractArray fallback uses scalar indexing, which errors on GPU
+Base.clamp!(F::AbstractField, lo, hi) = Field(clamp!(F.data, lo, hi), F.grid, F.dims)
 
 # make [:, k...] not escape the Field
 @inline Base.getindex(field::AbstractField, col::Colon, k...) = Field(field.data[col, k...], field.grid, field.dims[col, k...])

--- a/RingGrids/src/field.jl
+++ b/RingGrids/src/field.jl
@@ -124,12 +124,15 @@ matrix_size(field::AbstractField) = (matrix_size(field.grid)..., size(field)[2:e
 Base.@propagate_inbounds Base.getindex(field::AbstractField, ijk...) = getindex(field.data, ijk...)
 Base.@propagate_inbounds Base.setindex!(field::AbstractField, x, ijk...) = setindex!(field.data, x, ijk...)
 function Base.fill!(field::AbstractField, x) 
-                  fill!(field.data, x)
-                  return field
+    fill!(field.data, x)
+    return field
 end 
 
 # defined explicitly as the generic AbstractArray fallback uses scalar indexing, which errors on GPU
-Base.clamp!(field::AbstractField, lo, hi) = nonparametric_type(typeof(field))(clamp!(field.data, lo, hi), field.grid, field.dims)
+function Base.clamp!(field::AbstractField, lo, hi)
+    clamp!(field.data, lo, hi)
+    return field
+end
 
 # make [:, k...] not escape the Field
 @inline Base.getindex(field::AbstractField, col::Colon, k...) = Field(field.data[col, k...], field.grid, field.dims[col, k...])

--- a/RingGrids/test/column_field.jl
+++ b/RingGrids/test/column_field.jl
@@ -310,9 +310,16 @@ end
         column_field_gpu[1, :] = gpu_vec
         @test column_field_gpu[1, :] ≈ gpu_vec
 
-        # Test fill!
-        fill!(column_field_gpu, NF(42))
+        # Test fill! (returns a ColumnField, not the bare underlying array)
+        filled = fill!(column_field_gpu, NF(42))
         @test all(Array(column_field_gpu) .== NF(42))
+        @test filled isa ColumnField{NF, 2, JLArray{NF, 2}}
+
+        # Test clamp! (uses `column_field.data`'s clamp! to avoid scalar indexing on GPU)
+        column_field_gpu3 = on_architecture(jl_arch, ColumnField(randn(NF, nlayers, npoints), grid))
+        clamped = clamp!(column_field_gpu3, NF(-0.5), NF(0.5))
+        @test clamped isa ColumnField{NF, 2, JLArray{NF, 2}}
+        @test all(-0.5 .<= Array(clamped) .<= 0.5)
     end
 end
 

--- a/RingGrids/test/grids.jl
+++ b/RingGrids/test/grids.jl
@@ -548,9 +548,16 @@ end
         field[:, 1, 2] = v
         @test field[:, 1, 2].data ≈ v.data
 
-        # fill
-        fill!(field, 2.0)
+        # fill! (returns a Field, not the bare underlying array)
+        filled = fill!(field, 2.0)
         @test all(field .== 2)
+        @test filled isa Field{NF, ndims, JLArray{NF, ndims}}
+
+        # clamp! (uses `field.data`'s clamp! to avoid scalar indexing on GPU)
+        field3 = on_architecture(jl_arch, randn(F{NF}, s...))
+        clamped = clamp!(field3, NF(-0.5), NF(0.5))
+        @test clamped isa Field{NF, ndims, JLArray{NF, ndims}}
+        @test all(-0.5 .<= clamped .<= 0.5)
     end
 end
 

--- a/SpeedyWeather/src/parameterizations/land_sea_mask.jl
+++ b/SpeedyWeather/src/parameterizations/land_sea_mask.jl
@@ -110,8 +110,10 @@ end
 function set!(mask::AbstractLandSeaMask, args...; kwargs...)
     set!(mask.land_fraction, args...; kwargs...)
     lo, hi = extrema(mask.land_fraction)
-    (lo < 0 || hi > 1) && @warn "Land-sea mask not in [0, 1] but in [$lo, $hi]. Clamping."
-    clamp!(mask.land_fraction, 0, 1)
+    if lo < 0 || hi > 1
+        @warn "Land-sea mask not in [0, 1] but in [$lo, $hi]. Clamping."
+        clamp!(mask.land_fraction, 0, 1)
+    end
     return nothing
 end
 

--- a/SpeedyWeather/test/parameterizations/land_sea_mask.jl
+++ b/SpeedyWeather/test/parameterizations/land_sea_mask.jl
@@ -9,3 +9,17 @@
         @test simulation.model.feedback.nans_detected == false
     end
 end
+
+@testset "Land sea mask set! clamping" begin
+    spectral_grid = SpectralGrid(truncation = 32, nlayers = 8)
+    mask = LandSeaMask(spectral_grid)
+
+    # out of [0, 1] range: should warn and clamp
+    @test_logs (:warn,) set!(mask, 1.5)
+    @test all(mask.land_fraction .== 1)
+
+    # already in [0, 1] range: no warning, values unchanged
+    set!(mask, 0.3)
+    @test_logs set!(mask, 0.3)
+    @test all(mask.land_fraction .== eltype(mask.land_fraction)(0.3))
+end


### PR DESCRIPTION
## Problem
```julia
julia> set!(model, land_sea_mask = (λ, ϕ) -> if 0 <= λ < 180 1 else 0 end)
ERROR: Scalar indexing is disallowed.
```

## Summary

- `set!(model, land_sea_mask = ...)` threw a GPU scalar-indexing error because `AbstractField` had no specialized `clamp!` and fell back to the generic `AbstractArray` implementation, which iterates element-by-element. Add `Base.clamp!(F::AbstractField, lo, hi)` that operates on `F.data` directly (mirroring the existing `fill!` pattern), avoiding scalar indexing on GPU.
- Make `fill!` for `AbstractField` return a `Field` (rather than the bare underlying array), for consistency with the new `clamp!`.
- In `set!` for `AbstractLandSeaMask`, only call `clamp!` inside the `if` branch where the mask is actually out of `[0, 1]`, instead of unconditionally clamping every call.

Thanks to @hannahw0od for surfacing this GPU issue.

## Test plan
- [x] Added GPU-array (`JLArray`) tests for `clamp!` and `fill!` in `RingGrids/test/grids.jl` (`AbstractField: GPU (JLArrays)` testset)
- [x] Added a `set!` clamping test in `SpeedyWeather/test/parameterizations/land_sea_mask.jl`
- [x] Ran `RingGrids/test/grids.jl` and `SpeedyWeather/test/parameterizations/land_sea_mask.jl` locally, all passing
- [x] `runic --check` clean